### PR TITLE
Update project name to ATT&CK Workbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Federated ATT&CK REST API
-- [Federated ATT&CK Frontend](https://github.com/center-for-threat-informed-defense/federated-attack-frontend): the front-end UI for the Federated ATT&CK Editor.
-- [Federated ATT&CK Collection Manager](https://github.com/center-for-threat-informed-defense/federated-attack-collection-manager): REST API and CLI for managing collections.
-- Federated ATT&CK REST API: REST API service for storing, querying and editing ATT&CK objects.
+# ATT&CK Workbench REST API
+- [ATT&CK Workbench Frontend](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend): the front-end UI for the ATT&CK Workbench tool.
+- [ATT&CK Workbench Collection Manager](https://github.com/center-for-threat-informed-defense/attack-workbench-collection-manager): REST API and CLI for managing collections.
+- ATT&CK Workbench REST API: REST API service for storing, querying and editing ATT&CK objects.
 
 ## Scripts
 

--- a/app/config/config.js
+++ b/app/config/config.js
@@ -5,7 +5,7 @@ module.exports = {
         port: process.env.PORT || 3000
     },
     app: {
-        name: 'federated-attack-rest-api',
+        name: 'attack-workbench-rest-api',
         env: process.env.NODE_ENV || 'development'
     },
     database: {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 // Configure the logger
 const logger = require('./app/lib/logger');
 
-logger.info('Federated ATT&CK REST API app starting');
+logger.info('ATT&CK Workbench REST API app starting');
 
 const os = require('os');
 logger.info('** hostname = ' + os.hostname());
@@ -56,7 +56,7 @@ const server = app.listen(config.server.port, function () {
     const port = server.address().port;
 
     logger.info(`Listening at http://${host}:${port}`);
-    logger.info('Federated ATT&CK REST API start up complete');
+    logger.info('ATT&CK Workbench REST API start up complete');
 });
 
 module.exports = app;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "federated-attack-rest-api",
+  "name": "attack-workbench-rest-api",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "federated-attack-rest-api",
+  "name": "attack-workbench-rest-api",
   "version": "0.0.0",
-  "description": "REST API service for the ATT&CK Workspace.",
+  "description": "REST API service for the ATT&CK Workbench.",
   "main": "index.js",
   "scripts": {
     "api:generate-md": "widdershins ./app/api/definitions/api.yml -o ./app/api/markdown/api.md --summary",


### PR DESCRIPTION
Change `Federated ATT&CK` to `ATT&CK Workbench`. 

Note: does not affect in progress branches such as develop, nor files in `app/api/` which appear to be autogenerated (should this be gitignored?)
