### PR TITLE
Add CORS

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -20,6 +20,11 @@ exports.initializeApp = async function() {
     const express = require('express');
     app = express();
 
+    // Allow CORS
+    // TBD: Configure CORS for a specific origin
+    const cors = require('cors');
+    app.use(cors());
+
     // Compress response bodies
     const compression = require('compression');
     app.use(compression());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1365,6 +1365,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.6",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-openapi-validator": "^4.2.0",
     "helmet": "^4.1.1",


### PR DESCRIPTION
Allow CORS so as to support front-end requests. Without this, the front-end cannot access the API. 

See also https://github.com/center-for-threat-informed-defense/attack-workbench-collection-manager/commit/fdf089523e8511c2c66f9ac561e0f5fb7b6194a7