### PR TITLE
When querying by id, return a 404 when the object doesn't exist.

### DIFF
--- a/app/api/definitions/openapi.yml
+++ b/app/api/definitions/openapi.yml
@@ -137,6 +137,8 @@ paths:
                 type: array
                 items:
                   $ref: 'techniques.yml#/components/schemas/technique'
+        '404':
+          description: 'A technique with the requested STIX id was not found.'
 
   /api/techniques/{stixId}/modified/{modified}:
     get:
@@ -313,6 +315,8 @@ paths:
                 type: array
                 items:
                   $ref: 'tactics.yml#/components/schemas/tactic'
+        '404':
+          description: 'A tactic with the requested STIX id was not found.'
 
   /api/tactics/{stixId}/modified/{modified}:
     get:
@@ -489,6 +493,8 @@ paths:
                 type: array
                 items:
                   $ref: 'groups.yml#/components/schemas/group'
+        '404':
+          description: 'A group with the requested STIX id was not found.'
 
   /api/groups/{stixId}/modified/{modified}:
     get:
@@ -665,6 +671,8 @@ paths:
                 type: array
                 items:
                   $ref: 'collection-indexes.yml#/components/schemas/collection-index-wrapper'
+        '404':
+          description: 'A collection index with the requested id was not found.'
     put:
       summary: 'Update a collection index'
       operationId: 'collection-index-update'

--- a/app/controllers/collection-indexes-controller.js
+++ b/app/controllers/collection-indexes-controller.js
@@ -31,17 +31,18 @@ exports.retrieveById = function(req, res) {
                 logger.warn('Badly formatted id: ' + id);
                 return res.status(400).send('Id is badly formatted.');
             }
-            else if (err.message === techniquesService.errors.invalidQueryStringParameter) {
-                logger.warn('Invalid query string: versions=' + req.query.versions);
-                return res.status(400).send('Query string parameter versions is invalid.');
-            }
             else {
                 logger.error('Failed with error: ' + err);
                 return res.status(500).send('Unable to get collection index. Server error.');
             }
         }
         else {
-            return res.status(200).send(collectionIndex);
+            if (collectionIndex) {
+                return res.status(200).send(collectionIndex);
+            }
+            else {
+                return res.status(404).send('Collection Index not found.');
+            }
         }
     });
 };

--- a/app/controllers/groups-controller.js
+++ b/app/controllers/groups-controller.js
@@ -35,8 +35,13 @@ exports.retrieveById = function(req, res) {
             }
         }
         else {
-            logger.debug(`Success: Retrieved ${ groups.length } group(s) with id ${ req.params.stixId }`);
-            return res.status(200).send(groups);
+            if (groups.length === 0) {
+                return res.status(404).send('Group not found.');
+            }
+            else {
+                logger.debug(`Success: Retrieved ${ groups.length } group(s) with id ${ req.params.stixId }`);
+                return res.status(200).send(groups);
+            }
         }
     });
 };

--- a/app/controllers/tactics-controller.js
+++ b/app/controllers/tactics-controller.js
@@ -35,8 +35,13 @@ exports.retrieveById = function(req, res) {
             }
         }
         else {
-            logger.debug(`Success: Retrieved ${ tactics.length } tactic(s) with id ${ req.params.stixId }`);
-            return res.status(200).send(tactics);
+            if (tactics.length === 0) {
+                return res.status(404).send('Tactic not found.');
+            }
+            else {
+                logger.debug(`Success: Retrieved ${ tactics.length } tactic(s) with id ${ req.params.stixId }`);
+                return res.status(200).send(tactics);
+            }
         }
     });
 };

--- a/app/controllers/techniques-controller.js
+++ b/app/controllers/techniques-controller.js
@@ -43,8 +43,13 @@ exports.retrieveById = function(req, res) {
             }
         }
         else {
-            logger.debug(`Success: Retrieved ${ techniques.length } technique(s) with id ${ req.params.stixId }`);
-            return res.status(200).send(techniques);
+            if (techniques.length === 0) {
+                return res.status(404).send('Technique not found.');
+            }
+            else {
+                logger.debug(`Success: Retrieved ${ techniques.length } technique(s) with id ${ req.params.stixId }`);
+                return res.status(200).send(techniques);
+            }
         }
     });
 };

--- a/app/services/collection-indexes-service.js
+++ b/app/services/collection-indexes-service.js
@@ -45,11 +45,7 @@ exports.retrieveById = function(id, callback) {
                 }
             } else {
                 // Note: document is null if not found
-                if (collectionIndex) {
-                    return callback(null, collectionIndex);
-                } else {
-                    return callback(null, []);
-                }
+                return callback(null, collectionIndex);
             }
         });
 };

--- a/app/tests/api/collectionIndexes/collectionIndexes.spec.js
+++ b/app/tests/api/collectionIndexes/collectionIndexes.spec.js
@@ -153,6 +153,20 @@ describe('Collection Indexes Basic API', function () {
             });
     });
 
+    it('GET /api/collection-indexes/:id should not return a collection index when the id cannot be found', function (done) {
+        request(app)
+            .get('/api/collection-indexes/not-an-id')
+            .set('Accept', 'application/json')
+            .expect(404)
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    done();
+                }
+            });
+    });
+
     it('GET /api/collection-indexes/:id returns the added collection index', function (done) {
         request(app)
             .get('/api/collection-indexes/' + collectionIndex1.collection_index.id)

--- a/app/tests/api/groups/groups.spec.js
+++ b/app/tests/api/groups/groups.spec.js
@@ -121,6 +121,20 @@ describe('Groups API', function () {
             });
     });
 
+    it('GET /api/groups/:id should not return a group when the id cannot be found', function (done) {
+        request(app)
+            .get('/api/groups/not-an-id')
+            .set('Accept', 'application/json')
+            .expect(404)
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    done();
+                }
+            });
+    });
+
     it('GET /api/groups/:id returns the added group', function (done) {
         request(app)
             .get('/api/groups/' + group1.stix.id)

--- a/app/tests/api/tactics/tactics.spec.js
+++ b/app/tests/api/tactics/tactics.spec.js
@@ -121,6 +121,20 @@ describe('Tactics API', function () {
             });
     });
 
+    it('GET /api/tactics/:id should not return a tactic when the id cannot be found', function (done) {
+        request(app)
+            .get('/api/tactics/not-an-id')
+            .set('Accept', 'application/json')
+            .expect(404)
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    done();
+                }
+            });
+    });
+
     it('GET /api/tactics/:id returns the added tactic', function (done) {
         request(app)
             .get('/api/tactics/' + tactic1.stix.id)

--- a/app/tests/api/techniques/techniques.spec.js
+++ b/app/tests/api/techniques/techniques.spec.js
@@ -126,6 +126,20 @@ describe('Techniques Basic API', function () {
             });
     });
 
+    it('GET /api/techniques/:id should not return a technique when the id cannot be found', function (done) {
+        request(app)
+            .get('/api/techniques/not-an-id')
+            .set('Accept', 'application/json')
+            .expect(404)
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    done();
+                }
+            });
+    });
+
     it('GET /api/techniques/:id returns the added technique', function (done) {
         request(app)
             .get('/api/techniques/' + technique1.stix.id)


### PR DESCRIPTION
Endpoints in the form `/api/object-type/:id` now return a 404 if no objects with the id exist. Also updates the openAPI spec and adds a test for this case.

Closes #21 