### PR TITLE
Add ICS platforms to allowed-values

### DIFF
--- a/app/config/allowed-values.json
+++ b/app/config/allowed-values.json
@@ -29,7 +29,16 @@
           },
           {
             "domainName": "ics-attack",
-            "allowedValues": [ ]
+            "allowedValues": [
+              "Field Controller/RTU/PLC/IED",
+              "Safety Instrumented System/Protection Relay",
+              "Control Server",
+              "Input/Output Server",
+              "Windows",
+              "Human-Machine Interface",
+              "Engineering Workstation",
+              "Data Historian"
+            ]
           }
         ]
       },
@@ -41,7 +50,8 @@
             "allowedValues": [
               "Post-Adversary Device Access",
               "Pre-Adversary Device Access",
-              "Without Adversary Device Access"            ]
+              "Without Adversary Device Access"
+            ]
           }
         ]
       },
@@ -120,7 +130,16 @@
           },
           {
             "domainName": "ics-attack",
-            "allowedValues": [ ]
+            "allowedValues": [
+              "Field Controller/RTU/PLC/IED",
+              "Safety Instrumented System/Protection Relay",
+              "Control Server",
+              "Input/Output Server",
+              "Windows",
+              "Human-Machine Interface",
+              "Engineering Workstation",
+              "Data Historian"
+            ]
           }
         ]
       }


### PR DESCRIPTION
Update `x_mitre_platforms` in allowed-values to specify options for the ICS. Previously there were no options listed for that domain.