### PR TITLE
update ci-workflow to use codecov actions instead of bash-uploader

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -17,12 +17,12 @@ jobs:
       - run: npm install
       - run: npm run lint
       - run: npm run snyk
-      - run: $(npm bin)/nyc --reporter=lcov npm test
+      - run: $(npm bin)/nyc --reporter=cobertura npm test
       - name: Upload Coverage to CodeCov
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_SECRET }}
-          files: coverage.xml
+          files: coverage/cobertura-coverage.xml
           verbose: true
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
This PR updates the CI workflow to use codecov actions instead of the bash-uploader.