### PR TITLE
Add data sources and data components endpoints

### DIFF
--- a/app/api/definitions/components/data-components.yml
+++ b/app/api/definitions/components/data-components.yml
@@ -1,0 +1,44 @@
+components:
+  schemas:
+    data-component:
+      type: object
+      required:
+        - workspace
+        - stix
+      properties:
+        workspace:
+          $ref: 'workspace.yml#/components/schemas/workspace'
+        stix:
+          $ref: '#/components/schemas/x-mitre-data-component'
+
+    x-mitre-data-component:
+      allOf:
+        - $ref: 'stix-common.yml#/components/schemas/stix-common'
+        - type: object
+          required:
+            - name
+          properties:
+            # data-component specific properties
+            name:
+              type: string
+              example: 'Data Component Name'
+            description:
+              type: string
+              example: 'This is a data component'
+            # ATT&CK custom properties
+            x_mitre_modified_by_ref:
+              type: string
+              example: 'identity--6444f546-6900-4456-b3b1-015c88d70dab'
+            x_mitre_data_source_ref:
+              type: string
+              example: 'x-mitre-data-source--6da9ab38-437f-4e2f-b24c-f0da3a8ce441'
+            x_mitre_deprecated:
+              type: boolean
+              example: false
+            x_mitre_domains:
+              type: array
+              items:
+                type: string
+            x_mitre_version:
+              type: string
+              example: '1.0'

--- a/app/api/definitions/components/data-sources.yml
+++ b/app/api/definitions/components/data-sources.yml
@@ -1,0 +1,55 @@
+components:
+  schemas:
+    data-source:
+      type: object
+      required:
+        - workspace
+        - stix
+      properties:
+        workspace:
+          $ref: 'workspace.yml#/components/schemas/workspace'
+        stix:
+          $ref: '#/components/schemas/x-mitre-data-source'
+
+    x-mitre-data-source:
+      allOf:
+        - $ref: 'stix-common.yml#/components/schemas/stix-common'
+        - type: object
+          required:
+            - name
+          properties:
+            # data-source specific properties
+            name:
+              type: string
+              example: 'Data Source Name'
+            description:
+              type: string
+              example: 'This is a data source'
+            # ATT&CK custom properties
+            x_mitre_modified_by_ref:
+              type: string
+              example: 'identity--6444f546-6900-4456-b3b1-015c88d70dab'
+            x_mitre_platforms:
+              type: array
+              items:
+                type: string
+                example: 'Windows'
+            x_mitre_contributors:
+              type: array
+              items:
+                type: string
+            x_mitre_deprecated:
+              type: boolean
+              example: false
+            x_mitre_domains:
+              type: array
+              items:
+                type: string
+            x_mitre_version:
+              type: string
+              example: '1.0'
+            x_mitre_collection_layers:
+              type: array
+              items:
+                type: string
+                example: 'host'

--- a/app/api/definitions/components/stix-common.yml
+++ b/app/api/definitions/components/stix-common.yml
@@ -11,7 +11,7 @@ components:
         # STIX common properties
         type:
           type: string
-          enum: ['attack-pattern', 'x-mitre-tactic', 'intrusion-set', 'tool', 'malware', 'course-of-action', 'x-mitre-matrix', 'identity', 'relationship', 'note', 'x-mitre-collection']
+          enum: ['attack-pattern', 'x-mitre-tactic', 'intrusion-set', 'tool', 'malware', 'course-of-action', 'x-mitre-matrix', 'identity', 'x-mitre-data-source', 'x-mitre-data-component', 'relationship', 'note', 'x-mitre-collection']
         spec_version:
           type: string
           pattern: '^2.1$'

--- a/app/api/definitions/openapi.yml
+++ b/app/api/definitions/openapi.yml
@@ -30,6 +30,10 @@ tags:
     description: 'Operations on identities'
   - name: 'Marking Definitions'
     description: 'Operations on marking definitions'
+  - name: 'Data Sources'
+    description: 'Operations on data sources'
+  - name: 'Data Components'
+    description: 'Operations on data components'
   - name: 'Relationships'
     description: 'Operations on relationships'
   - name: 'Notes'
@@ -128,6 +132,26 @@ paths:
 
   /api/mitigations/{stixId}/modified/{modified}:
     $ref: 'paths/mitigations-paths.yml#/paths/~1api~1mitigations~1{stixId}~1modified~1{modified}'
+
+  # Data Sources
+  /api/data-sources:
+    $ref: 'paths/data-sources-paths.yml#/paths/~1api~1data-sources'
+
+  /api/data-sources/{stixId}:
+    $ref: 'paths/data-sources-paths.yml#/paths/~1api~1data-sources~1{stixId}'
+
+  /api/data-sources/{stixId}/modified/{modified}:
+    $ref: 'paths/data-sources-paths.yml#/paths/~1api~1data-sources~1{stixId}~1modified~1{modified}'
+
+  # Data Components
+  /api/data-components:
+    $ref: 'paths/data-components-paths.yml#/paths/~1api~1data-components'
+
+  /api/data-components/{stixId}:
+    $ref: 'paths/data-components-paths.yml#/paths/~1api~1data-components~1{stixId}'
+
+  /api/data-components/{stixId}/modified/{modified}:
+    $ref: 'paths/data-components-paths.yml#/paths/~1api~1data-components~1{stixId}~1modified~1{modified}'
 
   # Relationships
   /api/relationships:

--- a/app/api/definitions/paths/data-components-paths.yml
+++ b/app/api/definitions/paths/data-components-paths.yml
@@ -1,0 +1,238 @@
+paths:
+  /api/data-components:
+    get:
+      summary: 'Get a list of data components'
+      operationId: 'data-component-get-all'
+      description: |
+        This endpoint gets a list of data components from the workspace.
+        The list of data components may include multiple versions of each data component.
+      tags:
+        - 'Data Components'
+      parameters:
+        - name: limit
+          in: query
+          description: |
+            The number of data components to retrieve.
+            The default (0) will retrieve all data components.
+          schema:
+            type: number
+            default: 0
+        - name: offset
+          in: query
+          description: |
+            The number of data components to skip.
+            The default (0) will start with the first data component.
+          schema:
+            type: number
+            default: 0
+        - name: state
+          in: query
+          description: |
+            State of the object in the editing workflow.
+            If this parameter is not set, objects will be retrieved regardless of state.
+            This parameter may be set multiple times to retrieve objects with any of the provided states.
+          schema:
+            oneOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
+          example: 'work-in-progress'
+        - name: includeRevoked
+          in: query
+          description: |
+            Whether to include objects that have the `revoked` property set to true.
+          schema:
+            type: boolean
+            default: false
+        - name: includeDeprecated
+          in: query
+          description: |
+            Whether to include objects that have the `x_mitre_deprecated` property set to true.
+          schema:
+            type: boolean
+            default: false
+        - name: search
+          in: query
+          description: |
+            Only return objects where the provided search text occurs in the `name` or `description`.
+            The search is case-insensitive.
+          schema:
+            type: string
+          example: 'windows'
+        - name: includePagination
+          in: query
+          description: |
+            Whether to include pagination data in the returned value.
+            Wraps returned objects in a larger object.
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: 'A list of data components.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '../components/data-components.yml#/components/schemas/data-component'
+
+    post:
+      summary: 'Create a data component'
+      operationId: 'data-component-create'
+      description: |
+        This endpoint creates a new data component in the workspace.
+        If the `stix.id` property is set, it creates a new version of an existing data component.
+        If the `stix.id` property is not set, it creates a new data component, generating a STIX id for it.
+      tags:
+        - 'Data Components'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../components/data-components.yml#/components/schemas/data-component'
+      responses:
+        '201':
+          description: 'The data component has been successfully created.'
+          content:
+            application/json:
+              schema:
+                $ref: '../components/data-components.yml#/components/schemas/data-component'
+        '400':
+          description: 'Missing or invalid parameters were provided. The data component was not created.'
+        '409':
+          description: 'Duplicate `stix.id` and `stix.modified` properties. The data component was not created.'
+
+  /api/data-components/{stixId}:
+    get:
+      summary: 'Get one or more versions of a data component'
+      operationId: 'data-component-get-one-id'
+      description: |
+        This endpoint gets a list of one or more versions of a data component from the workspace, identified by their STIX id.
+      tags:
+        - 'Data Components'
+      parameters:
+        - name: stixId
+          in: path
+          description: 'STIX id of the data component to retrieve'
+          required: true
+          schema:
+            type: string
+        - name: versions
+          in: query
+          description: |
+            The versions of the data component to retrieve.
+            `all` gets all versions of the data component, `latest` gets only the latest version.
+          schema:
+            type: string
+            enum:
+              - all
+              - latest
+            default: latest
+      responses:
+        '200':
+          description: 'A list of data components matching the requested STIX id.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '../components/data-components.yml#/components/schemas/data-component'
+        '404':
+          description: 'A data component with the requested STIX id was not found.'
+
+  /api/data-components/{stixId}/modified/{modified}:
+    get:
+      summary: 'Gets the version of a data component matching the STIX id and modified date'
+      operationId: 'data-component-get-by-id-and-modified'
+      description: |
+        This endpoint gets a single version of a data component from the workspace, identified by its STIX id and modified date.
+      tags:
+        - 'Data Components'
+      parameters:
+        - name: stixId
+          in: path
+          description: 'STIX id of the data component to retrieve'
+          required: true
+          schema:
+            type: string
+        - name: modified
+          in: path
+          description: 'modified date of the data component to retrieve'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'The version of a data component matching the STIX id and modified date.'
+          content:
+            application/json:
+              schema:
+                $ref: '../components/data-components.yml#/components/schemas/data-component'
+        '404':
+          description: 'A data component with the requested STIX id and modified date was not found.'
+    put:
+      summary: 'Update a data component'
+      operationId: 'data-component-update'
+      description: |
+        This endpoint updates a single version of a data component in the workspace, identified by its STIX id and modified date.
+      tags:
+        - 'Data Components'
+      parameters:
+        - name: stixId
+          in: path
+          description: 'STIX id of the data component to update'
+          required: true
+          schema:
+            type: string
+        - name: modified
+          in: path
+          description: 'modified date of the data component to update'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../components/data-components.yml#/components/schemas/data-component'
+      responses:
+        '200':
+          description: 'The data component was updated.'
+          content:
+            application/json:
+              schema:
+                $ref: '../components/data-components.yml#/components/schemas/data-component'
+        '400':
+          description: 'Missing or invalid parameters were provided. The data component was not updated.'
+        '404':
+          description: 'A data component with the requested STIX id and modified date was not found.'
+    delete:
+      summary: 'Delete a data component'
+      operationId: 'data-component-delete'
+      description: |
+        This endpoint deletes a single version of a data component from the workspace.
+        The data component is identified by its STIX id and modified date.
+      tags:
+        - 'Data Components'
+      parameters:
+        - name: stixId
+          in: path
+          description: 'STIX id of the data component to delete'
+          required: true
+          schema:
+            type: string
+        - name: modified
+          in: path
+          description: 'modified date of the data component to delete'
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 'The data component was successfully deleted.'
+        '404':
+          description: 'A data component with the requested STIX id and modified date was not found.'

--- a/app/api/definitions/paths/data-sources-paths.yml
+++ b/app/api/definitions/paths/data-sources-paths.yml
@@ -131,6 +131,14 @@ paths:
               - all
               - latest
             default: latest
+        - name: retrieveDataComponents
+          in: query
+          description: |
+            Retrieve the data components that reference the data source.
+            Note that this option always retrieves the latest version of a data component.
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: 'A list of data sources matching the requested STIX id.'
@@ -164,6 +172,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: retrieveDataComponents
+          in: query
+          description: |
+            Retrieve the data components that reference the data source.
+            Note that this option always retrieves the latest version of a data component.
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: 'The version of a data source matching the STIX id and modified date.'

--- a/app/api/definitions/paths/data-sources-paths.yml
+++ b/app/api/definitions/paths/data-sources-paths.yml
@@ -1,0 +1,238 @@
+paths:
+  /api/data-sources:
+    get:
+      summary: 'Get a list of data sources'
+      operationId: 'data-source-get-all'
+      description: |
+        This endpoint gets a list of data sources from the workspace.
+        The list of data sources may include multiple versions of each data source.
+      tags:
+        - 'Data Sources'
+      parameters:
+        - name: limit
+          in: query
+          description: |
+            The number of data sources to retrieve.
+            The default (0) will retrieve all data sources.
+          schema:
+            type: number
+            default: 0
+        - name: offset
+          in: query
+          description: |
+            The number of data sources to skip.
+            The default (0) will start with the first data source.
+          schema:
+            type: number
+            default: 0
+        - name: state
+          in: query
+          description: |
+            State of the object in the editing workflow.
+            If this parameter is not set, objects will be retrieved regardless of state.
+            This parameter may be set multiple times to retrieve objects with any of the provided states.
+          schema:
+            oneOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
+          example: 'work-in-progress'
+        - name: includeRevoked
+          in: query
+          description: |
+            Whether to include objects that have the `revoked` property set to true.
+          schema:
+            type: boolean
+            default: false
+        - name: includeDeprecated
+          in: query
+          description: |
+            Whether to include objects that have the `x_mitre_deprecated` property set to true.
+          schema:
+            type: boolean
+            default: false
+        - name: search
+          in: query
+          description: |
+            Only return objects where the provided search text occurs in the `name` or `description`.
+            The search is case-insensitive.
+          schema:
+            type: string
+          example: 'windows'
+        - name: includePagination
+          in: query
+          description: |
+            Whether to include pagination data in the returned value.
+            Wraps returned objects in a larger object.
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: 'A list of data sources.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '../components/data-sources.yml#/components/schemas/data-source'
+
+    post:
+      summary: 'Create a data source'
+      operationId: 'data-source-create'
+      description: |
+        This endpoint creates a new data source in the workspace.
+        If the `stix.id` property is set, it creates a new version of an existing data source.
+        If the `stix.id` property is not set, it creates a new data source, generating a STIX id for it.
+      tags:
+        - 'Data Sources'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../components/data-sources.yml#/components/schemas/data-source'
+      responses:
+        '201':
+          description: 'The data source has been successfully created.'
+          content:
+            application/json:
+              schema:
+                $ref: '../components/data-sources.yml#/components/schemas/data-source'
+        '400':
+          description: 'Missing or invalid parameters were provided. The data source was not created.'
+        '409':
+          description: 'Duplicate `stix.id` and `stix.modified` properties. The data source was not created.'
+
+  /api/data-sources/{stixId}:
+    get:
+      summary: 'Get one or more versions of a data source'
+      operationId: 'data-source-get-one-id'
+      description: |
+        This endpoint gets a list of one or more versions of a data source from the workspace, identified by their STIX id.
+      tags:
+        - 'Data Sources'
+      parameters:
+        - name: stixId
+          in: path
+          description: 'STIX id of the data source to retrieve'
+          required: true
+          schema:
+            type: string
+        - name: versions
+          in: query
+          description: |
+            The versions of the data source to retrieve.
+            `all` gets all versions of the data source, `latest` gets only the latest version.
+          schema:
+            type: string
+            enum:
+              - all
+              - latest
+            default: latest
+      responses:
+        '200':
+          description: 'A list of data sources matching the requested STIX id.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '../components/data-sources.yml#/components/schemas/data-source'
+        '404':
+          description: 'A data source with the requested STIX id was not found.'
+
+  /api/data-sources/{stixId}/modified/{modified}:
+    get:
+      summary: 'Gets the version of a data source matching the STIX id and modified date'
+      operationId: 'data-source-get-by-id-and-modified'
+      description: |
+        This endpoint gets a single version of a data source from the workspace, identified by its STIX id and modified date.
+      tags:
+        - 'Data Sources'
+      parameters:
+        - name: stixId
+          in: path
+          description: 'STIX id of the data source to retrieve'
+          required: true
+          schema:
+            type: string
+        - name: modified
+          in: path
+          description: 'modified date of the data source to retrieve'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'The version of a data source matching the STIX id and modified date.'
+          content:
+            application/json:
+              schema:
+                $ref: '../components/data-sources.yml#/components/schemas/data-source'
+        '404':
+          description: 'A data source with the requested STIX id and modified date was not found.'
+    put:
+      summary: 'Update a data source'
+      operationId: 'data-source-update'
+      description: |
+        This endpoint updates a single version of a data source in the workspace, identified by its STIX id and modified date.
+      tags:
+        - 'Data Sources'
+      parameters:
+        - name: stixId
+          in: path
+          description: 'STIX id of the data source to update'
+          required: true
+          schema:
+            type: string
+        - name: modified
+          in: path
+          description: 'modified date of the data source to update'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../components/data-sources.yml#/components/schemas/data-source'
+      responses:
+        '200':
+          description: 'The data source was updated.'
+          content:
+            application/json:
+              schema:
+                $ref: '../components/data-sources.yml#/components/schemas/data-source'
+        '400':
+          description: 'Missing or invalid parameters were provided. The data source was not updated.'
+        '404':
+          description: 'A data source with the requested STIX id and modified date was not found.'
+    delete:
+      summary: 'Delete a data source'
+      operationId: 'data-source-delete'
+      description: |
+        This endpoint deletes a single version of a data source from the workspace.
+        The data source is identified by its STIX id and modified date.
+      tags:
+        - 'Data Sources'
+      parameters:
+        - name: stixId
+          in: path
+          description: 'STIX id of the data source to delete'
+          required: true
+          schema:
+            type: string
+        - name: modified
+          in: path
+          description: 'modified date of the data source to delete'
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 'The data source was successfully deleted.'
+        '404':
+          description: 'A data source with the requested STIX id and modified date was not found.'

--- a/app/api/definitions/paths/relationships-paths.yml
+++ b/app/api/definitions/paths/relationships-paths.yml
@@ -89,6 +89,7 @@ paths:
               - group
               - mitigation
               - software
+              - data-component
         - name: targetType
           in: query
           description: |

--- a/app/controllers/data-components-controller.js
+++ b/app/controllers/data-components-controller.js
@@ -1,0 +1,147 @@
+'use strict';
+
+const dataComponentsService = require('../services/data-components-service');
+const logger = require('../lib/logger');
+
+exports.retrieveAll = function(req, res) {
+    const options = {
+        offset: req.query.offset || 0,
+        limit: req.query.limit || 0,
+        state: req.query.state,
+        includeRevoked: req.query.includeRevoked,
+        includeDeprecated: req.query.includeDeprecated,
+        search: req.query.search,
+        includePagination: req.query.includePagination
+    }
+
+    dataComponentsService.retrieveAll(options, function(err, results) {
+        if (err) {
+            logger.error('Failed with error: ' + err);
+            return res.status(500).send('Unable to get data components. Server error.');
+        }
+        else {
+            if (options.includePagination) {
+                logger.debug(`Success: Retrieved ${ results.data.length } of ${ results.pagination.total } total data component(s)`);
+            }
+            else {
+                logger.debug(`Success: Retrieved ${ results.length } data component(s)`);
+            }
+            return res.status(200).send(results);
+        }
+    });
+};
+
+exports.retrieveById = function(req, res) {
+    const options = {
+        versions: req.query.versions || 'latest'
+    }
+
+    dataComponentsService.retrieveById(req.params.stixId, options, function (err, dataComponents) {
+        if (err) {
+            if (err.message === dataComponentsService.errors.badlyFormattedParameter) {
+                logger.warn('Badly formatted stix id: ' + req.params.stixId);
+                return res.status(400).send('Stix id is badly formatted.');
+            }
+            else if (err.message === dataComponentsService.errors.invalidQueryStringParameter) {
+                logger.warn('Invalid query string: versions=' + req.query.versions);
+                return res.status(400).send('Query string parameter versions is invalid.');
+            }
+            else {
+                logger.error('Failed with error: ' + err);
+                return res.status(500).send('Unable to get data component. Server error.');
+            }
+        }
+        else {
+            if (dataComponents.length === 0) {
+                return res.status(404).send('Data component not found.');
+            }
+            else {
+                logger.debug(`Success: Retrieved ${ dataComponents.length } data component(s) with id ${ req.params.stixId }`);
+                return res.status(200).send(dataComponents);
+            }
+        }
+    });
+};
+
+exports.retrieveVersionById = function(req, res) {
+    dataComponentsService.retrieveVersionById(req.params.stixId, req.params.modified, function (err, dataComponent) {
+        if (err) {
+            if (err.message === dataComponentsService.errors.badlyFormattedParameter) {
+                logger.warn('Badly formatted stix id: ' + req.params.stixId);
+                return res.status(400).send('Stix id is badly formatted.');
+            }
+            else {
+                logger.error('Failed with error: ' + err);
+                return res.status(500).send('Unable to get data component. Server error.');
+            }
+        } else {
+            if (!dataComponent) {
+                return res.status(404).send('Data component not found.');
+            }
+            else {
+                logger.debug(`Success: Retrieved data component with id ${dataComponent.id}`);
+                return res.status(200).send(dataComponent);
+            }
+        }
+    });
+};
+
+exports.create = async function(req, res) {
+    // Get the data from the request
+    const dataComponentData = req.body;
+
+    // Create the data component
+    try {
+        const dataComponent = await dataComponentsService.create(dataComponentData, { import: false });
+        logger.debug("Success: Created data component with id " + dataComponent.stix.id);
+        return res.status(201).send(dataComponent);
+    }
+    catch(err) {
+        if (err.message === dataComponentsService.errors.duplicateId) {
+            logger.warn("Duplicate stix.id and stix.modified");
+            return res.status(409).send('Unable to create data component. Duplicate stix.id and stix.modified properties.');
+        }
+        else {
+            logger.error("Failed with error: " + err);
+            return res.status(500).send("Unable to create data component. Server error.");
+        }
+    }
+};
+
+exports.updateFull = function(req, res) {
+    // Get the data from the request
+    const dataComponentData = req.body;
+
+    // Create the data component
+    dataComponentsService.updateFull(req.params.stixId, req.params.modified, dataComponentData, function(err, dataComponent) {
+        if (err) {
+            logger.error("Failed with error: " + err);
+            return res.status(500).send("Unable to update data component. Server error.");
+        }
+        else {
+            if (!dataComponent) {
+                return res.status(404).send('Data component not found.');
+            } else {
+                logger.debug("Success: Updated data component with id " + dataComponent.stix.id);
+                return res.status(200).send(dataComponent);
+            }
+        }
+    });
+};
+
+exports.delete = function(req, res) {
+    dataComponentsService.delete(req.params.stixId, req.params.modified, function (err, dataComponent) {
+        if (err) {
+            logger.error('Delete data component failed. ' + err);
+            return res.status(500).send('Unable to delete data component. Server error.');
+        }
+        else {
+            if (!dataComponent) {
+                return res.status(404).send('Data component not found.');
+            } else {
+                logger.debug("Success: Deleted data component with id " + dataComponent.stix.id);
+                return res.status(204).end();
+            }
+        }
+    });
+};

--- a/app/controllers/data-sources-controller.js
+++ b/app/controllers/data-sources-controller.js
@@ -1,0 +1,147 @@
+'use strict';
+
+const dataSourcesService = require('../services/data-sources-service');
+const logger = require('../lib/logger');
+
+exports.retrieveAll = function(req, res) {
+    const options = {
+        offset: req.query.offset || 0,
+        limit: req.query.limit || 0,
+        state: req.query.state,
+        includeRevoked: req.query.includeRevoked,
+        includeDeprecated: req.query.includeDeprecated,
+        search: req.query.search,
+        includePagination: req.query.includePagination
+    }
+
+    dataSourcesService.retrieveAll(options, function(err, results) {
+        if (err) {
+            logger.error('Failed with error: ' + err);
+            return res.status(500).send('Unable to get data sources. Server error.');
+        }
+        else {
+            if (options.includePagination) {
+                logger.debug(`Success: Retrieved ${ results.data.length } of ${ results.pagination.total } total data source(s)`);
+            }
+            else {
+                logger.debug(`Success: Retrieved ${ results.length } data source(s)`);
+            }
+            return res.status(200).send(results);
+        }
+    });
+};
+
+exports.retrieveById = function(req, res) {
+    const options = {
+        versions: req.query.versions || 'latest'
+    }
+
+    dataSourcesService.retrieveById(req.params.stixId, options, function (err, dataSources) {
+        if (err) {
+            if (err.message === dataSourcesService.errors.badlyFormattedParameter) {
+                logger.warn('Badly formatted stix id: ' + req.params.stixId);
+                return res.status(400).send('Stix id is badly formatted.');
+            }
+            else if (err.message === dataSourcesService.errors.invalidQueryStringParameter) {
+                logger.warn('Invalid query string: versions=' + req.query.versions);
+                return res.status(400).send('Query string parameter versions is invalid.');
+            }
+            else {
+                logger.error('Failed with error: ' + err);
+                return res.status(500).send('Unable to get data sources. Server error.');
+            }
+        }
+        else {
+            if (dataSources.length === 0) {
+                return res.status(404).send('Data source not found.');
+            }
+            else {
+                logger.debug(`Success: Retrieved ${ dataSources.length } data source(s) with id ${ req.params.stixId }`);
+                return res.status(200).send(dataSources);
+            }
+        }
+    });
+};
+
+exports.retrieveVersionById = function(req, res) {
+    dataSourcesService.retrieveVersionById(req.params.stixId, req.params.modified, function (err, dataSource) {
+        if (err) {
+            if (err.message === dataSourcesService.errors.badlyFormattedParameter) {
+                logger.warn('Badly formatted stix id: ' + req.params.stixId);
+                return res.status(400).send('Stix id is badly formatted.');
+            }
+            else {
+                logger.error('Failed with error: ' + err);
+                return res.status(500).send('Unable to get data source. Server error.');
+            }
+        } else {
+            if (!dataSource) {
+                return res.status(404).send('Data source not found.');
+            }
+            else {
+                logger.debug(`Success: Retrieved data source with id ${dataSource.id}`);
+                return res.status(200).send(dataSource);
+            }
+        }
+    });
+};
+
+exports.create = async function(req, res) {
+    // Get the data from the request
+    const dataSourceData = req.body;
+
+    // Create the data source
+    try {
+        const dataSource = await dataSourcesService.create(dataSourceData, { import: false });
+        logger.debug("Success: Created data source with id " + dataSource.stix.id);
+        return res.status(201).send(dataSource);
+    }
+    catch(err) {
+        if (err.message === dataSourcesService.errors.duplicateId) {
+            logger.warn("Duplicate stix.id and stix.modified");
+            return res.status(409).send('Unable to create data source. Duplicate stix.id and stix.modified properties.');
+        }
+        else {
+            logger.error("Failed with error: " + err);
+            return res.status(500).send("Unable to create data source. Server error.");
+        }
+    }
+};
+
+exports.updateFull = function(req, res) {
+    // Get the data from the request
+    const dataSourceData = req.body;
+
+    // Create the data source
+    dataSourcesService.updateFull(req.params.stixId, req.params.modified, dataSourceData, function(err, dataSource) {
+        if (err) {
+            logger.error("Failed with error: " + err);
+            return res.status(500).send("Unable to update data source. Server error.");
+        }
+        else {
+            if (!dataSource) {
+                return res.status(404).send('Data source not found.');
+            } else {
+                logger.debug("Success: Updated data source with id " + dataSource.stix.id);
+                return res.status(200).send(dataSource);
+            }
+        }
+    });
+};
+
+exports.delete = function(req, res) {
+    dataSourcesService.delete(req.params.stixId, req.params.modified, function (err, dataSource) {
+        if (err) {
+            logger.error('Delete data source failed. ' + err);
+            return res.status(500).send('Unable to delete data source. Server error.');
+        }
+        else {
+            if (!dataSource) {
+                return res.status(404).send('Data source not found.');
+            } else {
+                logger.debug("Success: Deleted data source with id " + dataSource.stix.id);
+                return res.status(204).end();
+            }
+        }
+    });
+};

--- a/app/controllers/data-sources-controller.js
+++ b/app/controllers/data-sources-controller.js
@@ -33,7 +33,8 @@ exports.retrieveAll = function(req, res) {
 
 exports.retrieveById = function(req, res) {
     const options = {
-        versions: req.query.versions || 'latest'
+        versions: req.query.versions || 'latest',
+        retrieveDataComponents: req.query.retrieveDataComponents
     }
 
     dataSourcesService.retrieveById(req.params.stixId, options, function (err, dataSources) {
@@ -64,7 +65,11 @@ exports.retrieveById = function(req, res) {
 };
 
 exports.retrieveVersionById = function(req, res) {
-    dataSourcesService.retrieveVersionById(req.params.stixId, req.params.modified, function (err, dataSource) {
+    const options = {
+        retrieveDataComponents: req.query.retrieveDataComponents
+    }
+
+    dataSourcesService.retrieveVersionById(req.params.stixId, req.params.modified, options, function (err, dataSource) {
         if (err) {
             if (err.message === dataSourcesService.errors.badlyFormattedParameter) {
                 logger.warn('Badly formatted stix id: ' + req.params.stixId);

--- a/app/models/data-component-model.js
+++ b/app/models/data-component-model.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const AttackObject = require('./attack-object-model');
+
+const stixDataComponent = {
+    // STIX x-mitre-data-component specific properties
+    modified: { type: Date, required: true },
+    name: { type: String, required: true },
+    description: String,
+
+    // ATT&CK custom stix properties
+    x_mitre_data_source_ref: String,
+    x_mitre_modified_by_ref: String,
+    x_mitre_deprecated: Boolean,
+    x_mitre_domains: [ String ],
+    x_mitre_version: String
+};
+
+// Create the definition
+const dataComponentDefinition = {
+    stix: {
+        ...stixDataComponent
+    }
+};
+
+// Create the schema
+const dataComponentSchema = new mongoose.Schema(dataComponentDefinition);
+
+// Create the model
+const DataComponentModel = AttackObject.discriminator('Data-Component', dataComponentSchema);
+
+module.exports = DataComponentModel;

--- a/app/models/data-source-model.js
+++ b/app/models/data-source-model.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const AttackObject = require('./attack-object-model');
+
+const stixDataSource = {
+    // STIX x-mitre-data-source specific properties
+    modified: { type: Date, required: true },
+    name: { type: String, required: true },
+    description: String,
+
+    // ATT&CK custom stix properties
+    x_mitre_modified_by_ref: String,
+    x_mitre_platforms: [ String ],
+    x_mitre_deprecated: Boolean,
+    x_mitre_domains: [ String ],
+    x_mitre_version: String,
+    x_mitre_contributors: [ String ],
+    x_mitre_collection_layers: [ String ]
+};
+
+// Create the definition
+const dataSourceDefinition = {
+    stix: {
+        ...stixDataSource
+    }
+};
+
+// Create the schema
+const dataSourceSchema = new mongoose.Schema(dataSourceDefinition);
+
+// Create the model
+const DataSourceModel = AttackObject.discriminator('Data-Source', dataSourceSchema);
+
+module.exports = DataSourceModel;

--- a/app/models/subschemas/stix-core.js
+++ b/app/models/subschemas/stix-core.js
@@ -31,6 +31,7 @@ module.exports.commonRequiredSDO = {
             'tool',
             'x-mitre-collection',
             'x-mitre-data-source',
+            'x-mitre-data-component',
             'x-mitre-matrix',
             'x-mitre-tactic'
         ]

--- a/app/routes/data-components-routes.js
+++ b/app/routes/data-components-routes.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const express = require('express');
+const dataComponentsController = require('../controllers/data-components-controller');
+
+const router = express.Router();
+
+router.route('/data-components')
+    .get(dataComponentsController.retrieveAll)
+    .post(dataComponentsController.create);
+
+router.route('/data-components/:stixId')
+    .get(dataComponentsController.retrieveById);
+
+router.route('/data-components/:stixId/modified/:modified')
+    .get(dataComponentsController.retrieveVersionById)
+    .put(dataComponentsController.updateFull)
+    //    .patch(dataComponentsController.updatePartial)
+    .delete(dataComponentsController.delete);
+
+module.exports = router;

--- a/app/routes/data-sources-routes.js
+++ b/app/routes/data-sources-routes.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const express = require('express');
+const dataSourcesController = require('../controllers/data-sources-controller');
+
+const router = express.Router();
+
+router.route('/data-sources')
+    .get(dataSourcesController.retrieveAll)
+    .post(dataSourcesController.create);
+
+router.route('/data-sources/:stixId')
+    .get(dataSourcesController.retrieveById);
+
+router.route('/data-sources/:stixId/modified/:modified')
+    .get(dataSourcesController.retrieveVersionById)
+    .put(dataSourcesController.updateFull)
+    //    .patch(dataSourcesController.updatePartial)
+    .delete(dataSourcesController.delete);
+
+module.exports = router;

--- a/app/services/collection-bundles-service.js
+++ b/app/services/collection-bundles-service.js
@@ -14,6 +14,8 @@ const markingDefinitionsService = require('../services/marking-definitions-servi
 const identitiesService = require('../services/identities-service');
 const notesService = require('../services/notes-service');
 const referencesService = require('../services/references-service');
+const dataSourcesService = require('../services/data-sources-service');
+const dataComponentsService = require('../services/data-components-service');
 
 const async = require('async');
 
@@ -192,6 +194,12 @@ exports.importBundle = function(collection, data, options, callback) {
                         }
                         else if (importObject.type === 'note') {
                             service = notesService;
+                        }
+                        else if (importObject.type === 'x-mitre-data-source') {
+                            service = dataSourcesService;
+                        }
+                        else if (importObject.type === 'x-mitre-data-component') {
+                            service = dataComponentsService;
                         }
 
                         if (service) {

--- a/app/services/data-components-service.js
+++ b/app/services/data-components-service.js
@@ -1,0 +1,331 @@
+'use strict';
+
+const uuid = require('uuid');
+const DataComponent = require('../models/data-component-model');
+const systemConfigurationService = require('./system-configuration-service');
+const identitiesService = require('./identities-service');
+
+const errors = {
+    missingParameter: 'Missing required parameter',
+    badlyFormattedParameter: 'Badly formatted parameter',
+    duplicateId: 'Duplicate id',
+    notFound: 'Document not found',
+    invalidQueryStringParameter: 'Invalid query string parameter'
+};
+exports.errors = errors;
+
+exports.retrieveAll = function(options, callback) {
+    // Build the query
+    const query = {};
+    if (!options.includeRevoked) {
+        query['stix.revoked'] = { $in: [null, false] };
+    }
+    if (!options.includeDeprecated) {
+        query['stix.x_mitre_deprecated'] = { $in: [null, false] };
+    }
+    if (typeof options.state !== 'undefined') {
+        if (Array.isArray(options.state)) {
+            query['workspace.workflow.state'] = { $in: options.state };
+        }
+        else {
+            query['workspace.workflow.state'] = options.state;
+        }
+    }
+
+    // Build the aggregation
+    // - Group the documents by stix.id, sorted by stix.modified
+    // - Use the last document in each group (according to the value of stix.modified)
+    // - Then apply query, skip and limit options
+    const aggregation = [
+        { $sort: { 'stix.id': 1, 'stix.modified': 1 } },
+        { $group: { _id: '$stix.id', document: { $last: '$$ROOT' }}},
+        { $replaceRoot: { newRoot: '$document' }},
+        { $sort: { 'stix.id': 1 }},
+        { $match: query }
+    ];
+
+    if (typeof options.search !== 'undefined') {
+        const match = { $match: { $or: [
+                    { 'stix.name': { '$regex': options.search, '$options': 'i' }},
+                    { 'stix.description': { '$regex': options.search, '$options': 'i' }}
+                ]}};
+        aggregation.push(match);
+    }
+
+    const facet = {
+        $facet: {
+            totalCount: [ { $count: 'totalCount' }],
+            documents: [ ]
+        }
+    };
+    if (options.offset) {
+        facet.$facet.documents.push({ $skip: options.offset });
+    }
+    else {
+        facet.$facet.documents.push({ $skip: 0 });
+    }
+    if (options.limit) {
+        facet.$facet.documents.push({ $limit: options.limit });
+    }
+    aggregation.push(facet);
+
+    // Retrieve the documents
+    DataComponent.aggregate(aggregation, function(err, results) {
+        if (err) {
+            return callback(err);
+        }
+        else {
+            identitiesService.addCreatedByAndModifiedByIdentitiesToAll(results[0].documents)
+                .then(function() {
+                    if (options.includePagination) {
+                        let derivedTotalCount = 0;
+                        if (results[0].totalCount.length > 0) {
+                            derivedTotalCount = results[0].totalCount[0].totalCount;
+                        }
+                        const returnValue = {
+                            pagination: {
+                                total: derivedTotalCount,
+                                offset: options.offset,
+                                limit: options.limit
+                            },
+                            data: results[0].documents
+                        };
+                        return callback(null, returnValue);
+                    }
+                    else {
+                        return callback(null, results[0].documents);
+                    }
+                });
+        }
+    });
+};
+
+exports.retrieveById = function(stixId, options, callback) {
+    // versions=all Retrieve all data components with the stixId
+    // versions=latest Retrieve the data components with the latest modified date for this stixId
+
+    if (!stixId) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'stixId';
+        return callback(error);
+    }
+
+    if (options.versions === 'all') {
+        DataComponent.find({'stix.id': stixId})
+            .lean()
+            .exec(function (err, dataComponents) {
+                if (err) {
+                    if (err.name === 'CastError') {
+                        const error = new Error(errors.badlyFormattedParameter);
+                        error.parameterName = 'stixId';
+                        return callback(error);
+                    } else {
+                        return callback(err);
+                    }
+                } else {
+                    identitiesService.addCreatedByAndModifiedByIdentitiesToAll(dataComponents)
+                        .then(() => callback(null, dataComponents));
+                }
+            });
+    }
+    else if (options.versions === 'latest') {
+        DataComponent.findOne({ 'stix.id': stixId })
+            .sort('-stix.modified')
+            .lean()
+            .exec(function(err, dataComponent) {
+                if (err) {
+                    if (err.name === 'CastError') {
+                        const error = new Error(errors.badlyFormattedParameter);
+                        error.parameterName = 'stixId';
+                        return callback(error);
+                    }
+                    else {
+                        return callback(err);
+                    }
+                }
+                else {
+                    // Note: document is null if not found
+                    if (dataComponent) {
+                        identitiesService.addCreatedByAndModifiedByIdentities(dataComponent)
+                            .then(() => callback(null, [ dataComponent ]));
+                    }
+                    else {
+                        return callback(null, []);
+                    }
+                }
+            });
+    }
+    else {
+        const error = new Error(errors.invalidQueryStringParameter);
+        error.parameterName = 'versions';
+        return callback(error);
+    }
+};
+
+exports.retrieveVersionById = function(stixId, modified, callback) {
+    // Retrieve the versions of the data component with the matching stixId and modified date
+
+    if (!stixId) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'stixId';
+        return callback(error);
+    }
+
+    if (!modified) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'modified';
+        return callback(error);
+    }
+
+    DataComponent.findOne({ 'stix.id': stixId, 'stix.modified': modified }, function(err, dataComponent) {
+        if (err) {
+            if (err.name === 'CastError') {
+                const error = new Error(errors.badlyFormattedParameter);
+                error.parameterName = 'stixId';
+                return callback(error);
+            }
+            else {
+                return callback(err);
+            }
+        }
+        else {
+            // Note: document is null if not found
+            if (dataComponent) {
+                identitiesService.addCreatedByAndModifiedByIdentities(dataComponent)
+                    .then(() => callback(null, dataComponent));
+            }
+            else {
+                console.log('** NOT FOUND')
+                return callback();
+            }
+        }
+    });
+};
+
+exports.createIsAsync = true;
+exports.create = async function(data, options) {
+    // This function handles two use cases:
+    //   1. This is a completely new object. Create a new object and generate the stix.id if not already
+    //      provided. Set both stix.created_by_ref and stix.x_mitre_modified_by_ref to the organization identity.
+    //   2. This is a new version of an existing object. Create a new object with the specified id.
+    //      Set stix.x_mitre_modified_by_ref to the organization identity.
+
+    // Create the document
+    const dataComponent = new DataComponent(data);
+
+    options = options || {};
+    if (!options.import) {
+        // Get the organization identity
+        const organizationIdentityRef = await systemConfigurationService.retrieveOrganizationIdentityRef();
+
+        // Check for an existing object
+        let existingObject;
+        if (dataComponent.stix.id) {
+            existingObject = await DataComponent.findOne({ 'stix.id': dataComponent.stix.id });
+        }
+
+        if (existingObject) {
+            // New version of an existing object
+            // Only set the x_mitre_modified_by_ref property
+            dataComponent.stix.x_mitre_modified_by_ref = organizationIdentityRef;
+        }
+        else {
+            // New object
+            // Assign a new STIX id if not already provided
+            dataComponent.stix.id = dataComponent.stix.id || `x-mitre-data-component--${uuid.v4()}`;
+
+            // Set the created_by_ref and x_mitre_modified_by_ref properties
+            dataComponent.stix.created_by_ref = organizationIdentityRef;
+            dataComponent.stix.x_mitre_modified_by_ref = organizationIdentityRef;
+        }
+    }
+
+    // Save the document in the database
+    try {
+        const savedDataComponent = await dataComponent.save();
+        return savedDataComponent;
+    }
+    catch (err) {
+        if (err.name === 'MongoError' && err.code === 11000) {
+            // 11000 = Duplicate index
+            const error = new Error(errors.duplicateId);
+            throw error;
+        }
+        else {
+            throw err;
+        }
+    }
+};
+
+exports.updateFull = function(stixId, stixModified, data, callback) {
+    if (!stixId) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'stixId';
+        return callback(error);
+    }
+
+    if (!stixModified) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'modified';
+        return callback(error);
+    }
+
+    DataComponent.findOne({ 'stix.id': stixId, 'stix.modified': stixModified }, function(err, document) {
+        if (err) {
+            if (err.name === 'CastError') {
+                var error = new Error(errors.badlyFormattedParameter);
+                error.parameterName = 'stixId';
+                return callback(error);
+            }
+            else {
+                return callback(err);
+            }
+        }
+        else if (!document) {
+            // document not found
+            return callback(null);
+        }
+        else {
+            // Copy data to found document and save
+            Object.assign(document, data);
+            document.save(function(err, savedDocument) {
+                if (err) {
+                    if (err.name === 'MongoError' && err.code === 11000) {
+                        // 11000 = Duplicate index
+                        var error = new Error(errors.duplicateId);
+                        return callback(error);
+                    }
+                    else {
+                        return callback(err);
+                    }
+                }
+                else {
+                    return callback(null, savedDocument);
+                }
+            });
+        }
+    });
+};
+
+exports.delete = function (stixId, stixModified, callback) {
+    if (!stixId) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'stixId';
+        return callback(error);
+    }
+
+    if (!stixModified) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'modified';
+        return callback(error);
+    }
+
+    DataComponent.findOneAndRemove({ 'stix.id': stixId, 'stix.modified': stixModified }, function (err, dataComponent) {
+        if (err) {
+            return callback(err);
+        } else {
+            // Note: data component is null if not found
+            return callback(null, dataComponent);
+        }
+    });
+};

--- a/app/services/data-components-service.js
+++ b/app/services/data-components-service.js
@@ -100,6 +100,87 @@ exports.retrieveAll = function(options, callback) {
     });
 };
 
+exports.retrieveAllAsync = async function(options) {
+    // Build the query
+    const query = {};
+    if (!options.includeRevoked) {
+        query['stix.revoked'] = { $in: [null, false] };
+    }
+    if (!options.includeDeprecated) {
+        query['stix.x_mitre_deprecated'] = { $in: [null, false] };
+    }
+    if (typeof options.state !== 'undefined') {
+        if (Array.isArray(options.state)) {
+            query['workspace.workflow.state'] = { $in: options.state };
+        } else {
+            query['workspace.workflow.state'] = options.state;
+        }
+    }
+
+    // Build the aggregation
+    // - Group the documents by stix.id, sorted by stix.modified
+    // - Use the last document in each group (according to the value of stix.modified)
+    // - Then apply query, skip and limit options
+    const aggregation = [
+        { $sort: { 'stix.id': 1, 'stix.modified': 1 } },
+        { $group: { _id: '$stix.id', document: { $last: '$$ROOT' } } },
+        { $replaceRoot: { newRoot: '$document' } },
+        { $sort: { 'stix.id': 1 } },
+        { $match: query }
+    ];
+
+    if (typeof options.search !== 'undefined') {
+        const match = {
+            $match: {
+                $or: [
+                    { 'stix.name': { '$regex': options.search, '$options': 'i' } },
+                    { 'stix.description': { '$regex': options.search, '$options': 'i' } }
+                ]
+            }
+        };
+        aggregation.push(match);
+    }
+
+    const facet = {
+        $facet: {
+            totalCount: [{ $count: 'totalCount' }],
+            documents: []
+        }
+    };
+    if (options.offset) {
+        facet.$facet.documents.push({ $skip: options.offset });
+    } else {
+        facet.$facet.documents.push({ $skip: 0 });
+    }
+    if (options.limit) {
+        facet.$facet.documents.push({ $limit: options.limit });
+    }
+    aggregation.push(facet);
+
+    // Retrieve the documents
+    const results = await DataComponent.aggregate(aggregation);
+    await identitiesService.addCreatedByAndModifiedByIdentitiesToAll(results[0].documents);
+
+    if (options.includePagination) {
+        let derivedTotalCount = 0;
+        if (results[0].totalCount.length > 0) {
+            derivedTotalCount = results[0].totalCount[0].totalCount;
+        }
+        const returnValue = {
+            pagination: {
+                total: derivedTotalCount,
+                offset: options.offset,
+                limit: options.limit
+            },
+            data: results[0].documents
+        };
+        return returnValue;
+    }
+    else {
+        return results[0].documents;
+    }
+};
+
 exports.retrieveById = function(stixId, options, callback) {
     // versions=all Retrieve all data components with the stixId
     // versions=latest Retrieve the data components with the latest modified date for this stixId

--- a/app/services/data-sources-service.js
+++ b/app/services/data-sources-service.js
@@ -1,0 +1,331 @@
+'use strict';
+
+const uuid = require('uuid');
+const DataSource = require('../models/data-source-model');
+const systemConfigurationService = require('./system-configuration-service');
+const identitiesService = require('./identities-service');
+
+const errors = {
+    missingParameter: 'Missing required parameter',
+    badlyFormattedParameter: 'Badly formatted parameter',
+    duplicateId: 'Duplicate id',
+    notFound: 'Document not found',
+    invalidQueryStringParameter: 'Invalid query string parameter'
+};
+exports.errors = errors;
+
+exports.retrieveAll = function(options, callback) {
+    // Build the query
+    const query = {};
+    if (!options.includeRevoked) {
+        query['stix.revoked'] = { $in: [null, false] };
+    }
+    if (!options.includeDeprecated) {
+        query['stix.x_mitre_deprecated'] = { $in: [null, false] };
+    }
+    if (typeof options.state !== 'undefined') {
+        if (Array.isArray(options.state)) {
+            query['workspace.workflow.state'] = { $in: options.state };
+        }
+        else {
+            query['workspace.workflow.state'] = options.state;
+        }
+    }
+
+    // Build the aggregation
+    // - Group the documents by stix.id, sorted by stix.modified
+    // - Use the last document in each group (according to the value of stix.modified)
+    // - Then apply query, skip and limit options
+    const aggregation = [
+        { $sort: { 'stix.id': 1, 'stix.modified': 1 } },
+        { $group: { _id: '$stix.id', document: { $last: '$$ROOT' }}},
+        { $replaceRoot: { newRoot: '$document' }},
+        { $sort: { 'stix.id': 1 }},
+        { $match: query }
+    ];
+
+    if (typeof options.search !== 'undefined') {
+        const match = { $match: { $or: [
+                    { 'stix.name': { '$regex': options.search, '$options': 'i' }},
+                    { 'stix.description': { '$regex': options.search, '$options': 'i' }}
+                ]}};
+        aggregation.push(match);
+    }
+
+    const facet = {
+        $facet: {
+            totalCount: [ { $count: 'totalCount' }],
+            documents: [ ]
+        }
+    };
+    if (options.offset) {
+        facet.$facet.documents.push({ $skip: options.offset });
+    }
+    else {
+        facet.$facet.documents.push({ $skip: 0 });
+    }
+    if (options.limit) {
+        facet.$facet.documents.push({ $limit: options.limit });
+    }
+    aggregation.push(facet);
+
+    // Retrieve the documents
+    DataSource.aggregate(aggregation, function(err, results) {
+        if (err) {
+            return callback(err);
+        }
+        else {
+            identitiesService.addCreatedByAndModifiedByIdentitiesToAll(results[0].documents)
+                .then(function() {
+                    if (options.includePagination) {
+                        let derivedTotalCount = 0;
+                        if (results[0].totalCount.length > 0) {
+                            derivedTotalCount = results[0].totalCount[0].totalCount;
+                        }
+                        const returnValue = {
+                            pagination: {
+                                total: derivedTotalCount,
+                                offset: options.offset,
+                                limit: options.limit
+                            },
+                            data: results[0].documents
+                        };
+                        return callback(null, returnValue);
+                    }
+                    else {
+                        return callback(null, results[0].documents);
+                    }
+                });
+        }
+    });
+};
+
+exports.retrieveById = function(stixId, options, callback) {
+    // versions=all Retrieve all data sources with the stixId
+    // versions=latest Retrieve the data sources with the latest modified date for this stixId
+
+    if (!stixId) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'stixId';
+        return callback(error);
+    }
+
+    if (options.versions === 'all') {
+        DataSource.find({'stix.id': stixId})
+            .lean()
+            .exec(function (err, dataSources) {
+                if (err) {
+                    if (err.name === 'CastError') {
+                        const error = new Error(errors.badlyFormattedParameter);
+                        error.parameterName = 'stixId';
+                        return callback(error);
+                    } else {
+                        return callback(err);
+                    }
+                } else {
+                    identitiesService.addCreatedByAndModifiedByIdentitiesToAll(dataSources)
+                        .then(() => callback(null, dataSources));
+                }
+            });
+    }
+    else if (options.versions === 'latest') {
+        DataSource.findOne({ 'stix.id': stixId })
+            .sort('-stix.modified')
+            .lean()
+            .exec(function(err, dataSource) {
+                if (err) {
+                    if (err.name === 'CastError') {
+                        const error = new Error(errors.badlyFormattedParameter);
+                        error.parameterName = 'stixId';
+                        return callback(error);
+                    }
+                    else {
+                        return callback(err);
+                    }
+                }
+                else {
+                    // Note: document is null if not found
+                    if (dataSource) {
+                        identitiesService.addCreatedByAndModifiedByIdentities(dataSource)
+                            .then(() => callback(null, [ dataSource ]));
+                    }
+                    else {
+                        return callback(null, []);
+                    }
+                }
+            });
+    }
+    else {
+        const error = new Error(errors.invalidQueryStringParameter);
+        error.parameterName = 'versions';
+        return callback(error);
+    }
+};
+
+exports.retrieveVersionById = function(stixId, modified, callback) {
+    // Retrieve the versions of the data source with the matching stixId and modified date
+
+    if (!stixId) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'stixId';
+        return callback(error);
+    }
+
+    if (!modified) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'modified';
+        return callback(error);
+    }
+
+    DataSource.findOne({ 'stix.id': stixId, 'stix.modified': modified }, function(err, dataSource) {
+        if (err) {
+            if (err.name === 'CastError') {
+                const error = new Error(errors.badlyFormattedParameter);
+                error.parameterName = 'stixId';
+                return callback(error);
+            }
+            else {
+                return callback(err);
+            }
+        }
+        else {
+            // Note: document is null if not found
+            if (dataSource) {
+                identitiesService.addCreatedByAndModifiedByIdentities(dataSource)
+                    .then(() => callback(null, dataSource));
+            }
+            else {
+                console.log('** NOT FOUND')
+                return callback();
+            }
+        }
+    });
+};
+
+exports.createIsAsync = true;
+exports.create = async function(data, options) {
+    // This function handles two use cases:
+    //   1. This is a completely new object. Create a new object and generate the stix.id if not already
+    //      provided. Set both stix.created_by_ref and stix.x_mitre_modified_by_ref to the organization identity.
+    //   2. This is a new version of an existing object. Create a new object with the specified id.
+    //      Set stix.x_mitre_modified_by_ref to the organization identity.
+
+    // Create the document
+    const dataSource = new DataSource(data);
+
+    options = options || {};
+    if (!options.import) {
+        // Get the organization identity
+        const organizationIdentityRef = await systemConfigurationService.retrieveOrganizationIdentityRef();
+
+        // Check for an existing object
+        let existingObject;
+        if (dataSource.stix.id) {
+            existingObject = await DataSource.findOne({ 'stix.id': dataSource.stix.id });
+        }
+
+        if (existingObject) {
+            // New version of an existing object
+            // Only set the x_mitre_modified_by_ref property
+            dataSource.stix.x_mitre_modified_by_ref = organizationIdentityRef;
+        }
+        else {
+            // New object
+            // Assign a new STIX id if not already provided
+            dataSource.stix.id = dataSource.stix.id || `x-mitre-data-source--${uuid.v4()}`;
+
+            // Set the created_by_ref and x_mitre_modified_by_ref properties
+            dataSource.stix.created_by_ref = organizationIdentityRef;
+            dataSource.stix.x_mitre_modified_by_ref = organizationIdentityRef;
+        }
+    }
+
+    // Save the document in the database
+    try {
+        const savedDataSource = await dataSource.save();
+        return savedDataSource;
+    }
+    catch (err) {
+        if (err.name === 'MongoError' && err.code === 11000) {
+            // 11000 = Duplicate index
+            const error = new Error(errors.duplicateId);
+            throw error;
+        }
+        else {
+            throw err;
+        }
+    }
+};
+
+exports.updateFull = function(stixId, stixModified, data, callback) {
+    if (!stixId) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'stixId';
+        return callback(error);
+    }
+
+    if (!stixModified) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'modified';
+        return callback(error);
+    }
+
+    DataSource.findOne({ 'stix.id': stixId, 'stix.modified': stixModified }, function(err, document) {
+        if (err) {
+            if (err.name === 'CastError') {
+                var error = new Error(errors.badlyFormattedParameter);
+                error.parameterName = 'stixId';
+                return callback(error);
+            }
+            else {
+                return callback(err);
+            }
+        }
+        else if (!document) {
+            // document not found
+            return callback(null);
+        }
+        else {
+            // Copy data to found document and save
+            Object.assign(document, data);
+            document.save(function(err, savedDocument) {
+                if (err) {
+                    if (err.name === 'MongoError' && err.code === 11000) {
+                        // 11000 = Duplicate index
+                        var error = new Error(errors.duplicateId);
+                        return callback(error);
+                    }
+                    else {
+                        return callback(err);
+                    }
+                }
+                else {
+                    return callback(null, savedDocument);
+                }
+            });
+        }
+    });
+};
+
+exports.delete = function (stixId, stixModified, callback) {
+    if (!stixId) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'stixId';
+        return callback(error);
+    }
+
+    if (!stixModified) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'modified';
+        return callback(error);
+    }
+
+    DataSource.findOneAndRemove({ 'stix.id': stixId, 'stix.modified': stixModified }, function (err, dataSource) {
+        if (err) {
+            return callback(err);
+        } else {
+            // Note: data source is null if not found
+            return callback(null, dataSource);
+        }
+    });
+};

--- a/app/services/relationships-service.js
+++ b/app/services/relationships-service.js
@@ -14,6 +14,7 @@ const errors = {
 };
 exports.errors = errors;
 
+// Map STIX types to ATT&CK types
 const objectTypeMap = new Map();
 objectTypeMap.set('malware', 'software');
 objectTypeMap.set('tool', 'software');
@@ -22,6 +23,7 @@ objectTypeMap.set('intrusion-set', 'group');
 objectTypeMap.set('course-of-action', 'mitigation');
 objectTypeMap.set('x-mitre-tactic', 'tactic');
 objectTypeMap.set('x-mitre-matrix', 'matrix');
+objectTypeMap.set('x-mitre-data-component', 'data-component');
 
 exports.retrieveAll = function(options, callback) {
     // Build the query

--- a/app/tests/api/data-components/data-components-pagination.spec.js
+++ b/app/tests/api/data-components/data-components-pagination.spec.js
@@ -1,0 +1,30 @@
+const dataComponentsService = require('../../../services/data-components-service');
+const PaginationTests = require('../../shared/pagination');
+
+// modified and created properties will be set before calling REST API
+// stix.id property will be created by REST API
+const initialObjectData = {
+    workspace: {
+        workflow: {
+            state: 'work-in-progress'
+        }
+    },
+    stix: {
+        spec_version: '2.1',
+        type: 'x-mitre-data-component',
+        description: 'This is a data component.',
+        external_references: [
+            { source_name: 'source-1', external_id: 's1' }
+        ],
+        object_marking_refs: [ 'marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168' ],
+        created_by_ref: "identity--6444f546-6900-4456-b3b1-015c88d70dab"
+    }
+};
+
+const options = {
+    prefix: 'x-mitre-data-component',
+    baseUrl: '/api/data-components',
+    label: 'Data Components'
+}
+const paginationTests = new PaginationTests(dataComponentsService, initialObjectData, options);
+paginationTests.executeTests();

--- a/app/tests/api/data-components/data-components.spec.js
+++ b/app/tests/api/data-components/data-components.spec.js
@@ -1,0 +1,402 @@
+const request = require('supertest');
+const expect = require('expect');
+const _ = require('lodash');
+
+const database = require('../../../lib/database-in-memory');
+const databaseConfiguration = require('../../../lib/database-configuration');
+
+const logger = require('../../../lib/logger');
+logger.level = 'debug';
+
+// modified and created properties will be set before calling REST API
+// stix.id property will be created by REST API
+const initialObjectData = {
+    workspace: {
+        workflow: {
+            state: 'work-in-progress'
+        }
+    },
+    stix: {
+        name: 'data-component-1',
+        spec_version: '2.1',
+        type: 'x-mitre-data-component',
+        description: 'This is a data component.',
+        external_references: [
+            { source_name: 'source-1', external_id: 's1' }
+        ],
+        object_marking_refs: [ 'marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168' ],
+        created_by_ref: "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+        x_mitre_version: "1.1",
+        x_mitre_domains: [
+            'enterprise-attack'
+        ],
+        x_mitre_modified_by_ref: 'identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5'
+    }
+};
+
+describe('Data Components API', function () {
+    let app;
+
+    before(async function() {
+        // Establish the database connection
+        // Use an in-memory database that we spin up for the test
+        await database.initializeConnection();
+
+        // Check for a valid database configuration
+        await databaseConfiguration.checkSystemConfiguration();
+
+        // Initialize the express app
+        app = await require('../../../index').initializeApp();
+    });
+
+    it('GET /api/data-components returns an empty array of data components', function (done) {
+        request(app)
+            .get('/api/data-components')
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get an empty array
+                    const dataComponents = res.body;
+                    expect(dataComponents).toBeDefined();
+                    expect(Array.isArray(dataComponents)).toBe(true);
+                    expect(dataComponents.length).toBe(0);
+                    done();
+                }
+            });
+    });
+
+    it('POST /api/data-components does not create an empty data component', function (done) {
+        const body = { };
+        request(app)
+            .post('/api/data-components')
+            .send(body)
+            .set('Accept', 'application/json')
+            .expect(400)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    done();
+                }
+            });
+    });
+
+    let dataComponent1;
+    it('POST /api/data-components creates a data component', function (done) {
+        const timestamp = new Date().toISOString();
+        initialObjectData.stix.created = timestamp;
+        initialObjectData.stix.modified = timestamp;
+        const body = initialObjectData;
+        request(app)
+            .post('/api/data-components')
+            .send(body)
+            .set('Accept', 'application/json')
+            .expect(201)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get the created data component
+                    dataComponent1 = res.body;
+                    expect(dataComponent1).toBeDefined();
+                    expect(dataComponent1.stix).toBeDefined();
+                    expect(dataComponent1.stix.id).toBeDefined();
+                    expect(dataComponent1.stix.created).toBeDefined();
+                    expect(dataComponent1.stix.modified).toBeDefined();
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-components returns the added data component', function (done) {
+        request(app)
+            .get('/api/data-components')
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get one data component in an array
+                    const dataComponent = res.body;
+                    expect(dataComponent).toBeDefined();
+                    expect(Array.isArray(dataComponent)).toBe(true);
+                    expect(dataComponent.length).toBe(1);
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-components/:id should not return a data component when the id cannot be found', function (done) {
+        request(app)
+            .get('/api/data-components/not-an-id')
+            .set('Accept', 'application/json')
+            .expect(404)
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-components/:id returns the added data component', function (done) {
+        request(app)
+            .get('/api/data-components/' + dataComponent1.stix.id)
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get one data component in an array
+                    const dataComponents = res.body;
+                    expect(dataComponents).toBeDefined();
+                    expect(Array.isArray(dataComponents)).toBe(true);
+                    expect(dataComponents.length).toBe(1);
+
+                    const dataComponent = dataComponents[0];
+                    expect(dataComponent).toBeDefined();
+                    expect(dataComponent.stix).toBeDefined();
+                    expect(dataComponent.stix.id).toBe(dataComponent1.stix.id);
+                    expect(dataComponent.stix.type).toBe(dataComponent1.stix.type);
+                    expect(dataComponent.stix.name).toBe(dataComponent1.stix.name);
+                    expect(dataComponent.stix.description).toBe(dataComponent1.stix.description);
+                    expect(dataComponent.stix.spec_version).toBe(dataComponent1.stix.spec_version);
+                    expect(dataComponent.stix.object_marking_refs).toEqual(expect.arrayContaining(dataComponent1.stix.object_marking_refs));
+                    expect(dataComponent.stix.created_by_ref).toBe(dataComponent1.stix.created_by_ref);
+                    expect(dataComponent.stix.x_mitre_version).toBe(dataComponent1.stix.x_mitre_version);
+
+                    done();
+                }
+            });
+    });
+
+    it('PUT /api/data-components updates a data component', function (done) {
+        const originalModified = dataComponent1.stix.modified;
+        const timestamp = new Date().toISOString();
+        dataComponent1.stix.modified = timestamp;
+        dataComponent1.stix.description = 'This is an updated data component.'
+        const body = dataComponent1;
+        request(app)
+            .put('/api/data-components/' + dataComponent1.stix.id + '/modified/' + originalModified)
+            .send(body)
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get the updated data component
+                    const dataComponent = res.body;
+                    expect(dataComponent).toBeDefined();
+                    expect(dataComponent.stix.id).toBe(dataComponent1.stix.id);
+                    expect(dataComponent.stix.modified).toBe(dataComponent1.stix.modified);
+                    done();
+                }
+            });
+    });
+
+    it('POST /api/data-components does not create a data component with the same id and modified date', function (done) {
+        const body = dataComponent1;
+        request(app)
+            .post('/api/data-components')
+            .send(body)
+            .set('Accept', 'application/json')
+            .expect(409)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    done();
+                }
+            });
+    });
+
+    let dataComponent2;
+    it('POST /api/data-components should create a new version of a data component with a duplicate stix.id but different stix.modified date', function (done) {
+        dataComponent2 = _.cloneDeep(dataComponent1);
+        dataComponent2._id = undefined;
+        dataComponent2.__t = undefined;
+        dataComponent2.__v = undefined;
+        const timestamp = new Date().toISOString();
+        dataComponent2.stix.modified = timestamp;
+        const body = dataComponent2;
+        request(app)
+            .post('/api/data-components')
+            .send(body)
+            .set('Accept', 'application/json')
+            .expect(201)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get the created data component
+                    const dataComponent = res.body;
+                    expect(dataComponent).toBeDefined();
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-components returns the latest added data component', function (done) {
+        request(app)
+            .get('/api/data-components/' + dataComponent2.stix.id)
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get one data component in an array
+                    const dataComponents = res.body;
+                    expect(dataComponents).toBeDefined();
+                    expect(Array.isArray(dataComponents)).toBe(true);
+                    expect(dataComponents.length).toBe(1);
+                    const dataComponent = dataComponents[0];
+                    expect(dataComponent.stix.id).toBe(dataComponent2.stix.id);
+                    expect(dataComponent.stix.modified).toBe(dataComponent2.stix.modified);
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-components returns all added data component', function (done) {
+        request(app)
+            .get('/api/data-components/' + dataComponent1.stix.id + '?versions=all')
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get two data components in an array
+                    const dataComponents = res.body;
+                    expect(dataComponents).toBeDefined();
+                    expect(Array.isArray(dataComponents)).toBe(true);
+                    expect(dataComponents.length).toBe(2);
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-components/:id/modified/:modified returns the first added data component', function (done) {
+        request(app)
+            .get('/api/data-components/' + dataComponent1.stix.id + '/modified/' + dataComponent1.stix.modified)
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get one data component in an array
+                    const dataComponent = res.body;
+                    expect(dataComponent).toBeDefined();
+                    expect(dataComponent.stix).toBeDefined();
+                    expect(dataComponent.stix.id).toBe(dataComponent1.stix.id);
+                    expect(dataComponent.stix.modified).toBe(dataComponent1.stix.modified);
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-components/:id/modified/:modified returns the second added data component', function (done) {
+        request(app)
+            .get('/api/data-components/' + dataComponent2.stix.id + '/modified/' + dataComponent2.stix.modified)
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get one data component in an array
+                    const dataComponent = res.body;
+                    expect(dataComponent).toBeDefined();
+                    expect(dataComponent.stix).toBeDefined();
+                    expect(dataComponent.stix.id).toBe(dataComponent2.stix.id);
+                    expect(dataComponent.stix.modified).toBe(dataComponent2.stix.modified);
+                    done();
+                }
+            });
+    });
+
+    it('DELETE /api/data-components deletes a data component', function (done) {
+        request(app)
+            .delete('/api/data-components/' + dataComponent1.stix.id + '/modified/' + dataComponent1.stix.modified)
+            .expect(204)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    done();
+                }
+            });
+    });
+
+    it('DELETE /api/data-components should delete the second data component', function (done) {
+        request(app)
+            .delete('/api/data-components/' + dataComponent2.stix.id + '/modified/' + dataComponent2.stix.modified)
+            .expect(204)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-components returns an empty array of data components', function (done) {
+        request(app)
+            .get('/api/data-components')
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get an empty array
+                    const dataComponents = res.body;
+                    expect(dataComponents).toBeDefined();
+                    expect(Array.isArray(dataComponents)).toBe(true);
+                    expect(dataComponents.length).toBe(0);
+                    done();
+                }
+            });
+    });
+
+    after(async function() {
+        await database.closeConnection();
+    });
+});
+

--- a/app/tests/api/data-sources/data-sources-pagination.spec.js
+++ b/app/tests/api/data-sources/data-sources-pagination.spec.js
@@ -1,0 +1,30 @@
+const dataSourcesService = require('../../../services/data-sources-service');
+const PaginationTests = require('../../shared/pagination');
+
+// modified and created properties will be set before calling REST API
+// stix.id property will be created by REST API
+const initialObjectData = {
+    workspace: {
+        workflow: {
+            state: 'work-in-progress'
+        }
+    },
+    stix: {
+        spec_version: '2.1',
+        type: 'x-mitre-data-source',
+        description: 'This is a data source.',
+        external_references: [
+            { source_name: 'source-1', external_id: 's1' }
+        ],
+        object_marking_refs: [ 'marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168' ],
+        created_by_ref: "identity--6444f546-6900-4456-b3b1-015c88d70dab"
+    }
+};
+
+const options = {
+    prefix: 'x-mitre-data-source',
+    baseUrl: '/api/data-sources',
+    label: 'Data Sources'
+}
+const paginationTests = new PaginationTests(dataSourcesService, initialObjectData, options);
+paginationTests.executeTests();

--- a/app/tests/api/data-sources/data-sources.spec.js
+++ b/app/tests/api/data-sources/data-sources.spec.js
@@ -1,0 +1,416 @@
+const request = require('supertest');
+const expect = require('expect');
+const _ = require('lodash');
+
+const database = require('../../../lib/database-in-memory');
+const databaseConfiguration = require('../../../lib/database-configuration');
+
+const logger = require('../../../lib/logger');
+logger.level = 'debug';
+
+// modified and created properties will be set before calling REST API
+// stix.id property will be created by REST API
+const initialObjectData = {
+    workspace: {
+        workflow: {
+            state: 'work-in-progress'
+        }
+    },
+    stix: {
+        name: 'data-source-1',
+        spec_version: '2.1',
+        type: 'x-mitre-data-source',
+        description: 'This is a data source.',
+        external_references: [
+            { source_name: 'source-1', external_id: 's1' }
+        ],
+        object_marking_refs: [ 'marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168' ],
+        created_by_ref: "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+        x_mitre_version: "1.1",
+        x_mitre_platforms: [
+            'macOS',
+            'Office 365',
+            'Google Workspace',
+            'Linux',
+            'Network'
+        ],
+        x_mitre_collection_layers: [
+            'duis',
+            'laboris'
+        ],
+        x_mitre_contributors: [
+            'Herbert Examplecontributor'
+        ],
+        x_mitre_domains: [
+            'enterprise-attack'
+        ],
+        x_mitre_modified_by_ref: 'identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5'
+    }
+};
+
+describe('Data Sources API', function () {
+    let app;
+
+    before(async function() {
+        // Establish the database connection
+        // Use an in-memory database that we spin up for the test
+        await database.initializeConnection();
+
+        // Check for a valid database configuration
+        await databaseConfiguration.checkSystemConfiguration();
+
+        // Initialize the express app
+        app = await require('../../../index').initializeApp();
+    });
+
+    it('GET /api/data-sources returns an empty array of data sources', function (done) {
+        request(app)
+            .get('/api/data-sources')
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get an empty array
+                    const dataSources = res.body;
+                    expect(dataSources).toBeDefined();
+                    expect(Array.isArray(dataSources)).toBe(true);
+                    expect(dataSources.length).toBe(0);
+                    done();
+                }
+            });
+    });
+
+    it('POST /api/data-sources does not create an empty data source', function (done) {
+        const body = { };
+        request(app)
+            .post('/api/data-sources')
+            .send(body)
+            .set('Accept', 'application/json')
+            .expect(400)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    done();
+                }
+            });
+    });
+
+    let dataSource1;
+    it('POST /api/data-sources creates a data source', function (done) {
+        const timestamp = new Date().toISOString();
+        initialObjectData.stix.created = timestamp;
+        initialObjectData.stix.modified = timestamp;
+        const body = initialObjectData;
+        request(app)
+            .post('/api/data-sources')
+            .send(body)
+            .set('Accept', 'application/json')
+            .expect(201)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get the created data source
+                    dataSource1 = res.body;
+                    expect(dataSource1).toBeDefined();
+                    expect(dataSource1.stix).toBeDefined();
+                    expect(dataSource1.stix.id).toBeDefined();
+                    expect(dataSource1.stix.created).toBeDefined();
+                    expect(dataSource1.stix.modified).toBeDefined();
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-sources returns the added data source', function (done) {
+        request(app)
+            .get('/api/data-sources')
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get one data source in an array
+                    const dataSource = res.body;
+                    expect(dataSource).toBeDefined();
+                    expect(Array.isArray(dataSource)).toBe(true);
+                    expect(dataSource.length).toBe(1);
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-sources/:id should not return a data source when the id cannot be found', function (done) {
+        request(app)
+            .get('/api/data-sources/not-an-id')
+            .set('Accept', 'application/json')
+            .expect(404)
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-sources/:id returns the added data source', function (done) {
+        request(app)
+            .get('/api/data-sources/' + dataSource1.stix.id)
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get one data source in an array
+                    const dataSources = res.body;
+                    expect(dataSources).toBeDefined();
+                    expect(Array.isArray(dataSources)).toBe(true);
+                    expect(dataSources.length).toBe(1);
+
+                    const dataSource = dataSources[0];
+                    expect(dataSource).toBeDefined();
+                    expect(dataSource.stix).toBeDefined();
+                    expect(dataSource.stix.id).toBe(dataSource1.stix.id);
+                    expect(dataSource.stix.type).toBe(dataSource1.stix.type);
+                    expect(dataSource.stix.name).toBe(dataSource1.stix.name);
+                    expect(dataSource.stix.description).toBe(dataSource1.stix.description);
+                    expect(dataSource.stix.spec_version).toBe(dataSource1.stix.spec_version);
+                    expect(dataSource.stix.object_marking_refs).toEqual(expect.arrayContaining(dataSource1.stix.object_marking_refs));
+                    expect(dataSource.stix.created_by_ref).toBe(dataSource1.stix.created_by_ref);
+                    expect(dataSource.stix.x_mitre_version).toBe(dataSource1.stix.x_mitre_version);
+
+                    done();
+                }
+            });
+    });
+
+    it('PUT /api/data-sources updates a data source', function (done) {
+        const originalModified = dataSource1.stix.modified;
+        const timestamp = new Date().toISOString();
+        dataSource1.stix.modified = timestamp;
+        dataSource1.stix.description = 'This is an updated data source.'
+        const body = dataSource1;
+        request(app)
+            .put('/api/data-sources/' + dataSource1.stix.id + '/modified/' + originalModified)
+            .send(body)
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get the updated data source
+                    const dataSource = res.body;
+                    expect(dataSource).toBeDefined();
+                    expect(dataSource.stix.id).toBe(dataSource1.stix.id);
+                    expect(dataSource.stix.modified).toBe(dataSource1.stix.modified);
+                    done();
+                }
+            });
+    });
+
+    it('POST /api/data-sources does not create a data source with the same id and modified date', function (done) {
+        const body = dataSource1;
+        request(app)
+            .post('/api/data-sources')
+            .send(body)
+            .set('Accept', 'application/json')
+            .expect(409)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    done();
+                }
+            });
+    });
+
+    let dataSource2;
+    it('POST /api/data-sources should create a new version of a data source with a duplicate stix.id but different stix.modified date', function (done) {
+        dataSource2 = _.cloneDeep(dataSource1);
+        dataSource2._id = undefined;
+        dataSource2.__t = undefined;
+        dataSource2.__v = undefined;
+        const timestamp = new Date().toISOString();
+        dataSource2.stix.modified = timestamp;
+        const body = dataSource2;
+        request(app)
+            .post('/api/data-sources')
+            .send(body)
+            .set('Accept', 'application/json')
+            .expect(201)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get the created data source
+                    const dataSource = res.body;
+                    expect(dataSource).toBeDefined();
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-sources returns the latest added data source', function (done) {
+        request(app)
+            .get('/api/data-sources/' + dataSource2.stix.id)
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get one data source in an array
+                    const dataSources = res.body;
+                    expect(dataSources).toBeDefined();
+                    expect(Array.isArray(dataSources)).toBe(true);
+                    expect(dataSources.length).toBe(1);
+                    const dataSource = dataSources[0];
+                    expect(dataSource.stix.id).toBe(dataSource2.stix.id);
+                    expect(dataSource.stix.modified).toBe(dataSource2.stix.modified);
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-sources returns all added data source', function (done) {
+        request(app)
+            .get('/api/data-sources/' + dataSource1.stix.id + '?versions=all')
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get two data sources in an array
+                    const dataSources = res.body;
+                    expect(dataSources).toBeDefined();
+                    expect(Array.isArray(dataSources)).toBe(true);
+                    expect(dataSources.length).toBe(2);
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-sources/:id/modified/:modified returns the first added data source', function (done) {
+        request(app)
+            .get('/api/data-sources/' + dataSource1.stix.id + '/modified/' + dataSource1.stix.modified)
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get one data source in an array
+                    const dataSource = res.body;
+                    expect(dataSource).toBeDefined();
+                    expect(dataSource.stix).toBeDefined();
+                    expect(dataSource.stix.id).toBe(dataSource1.stix.id);
+                    expect(dataSource.stix.modified).toBe(dataSource1.stix.modified);
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-sources/:id/modified/:modified returns the second added data source', function (done) {
+        request(app)
+            .get('/api/data-sources/' + dataSource2.stix.id + '/modified/' + dataSource2.stix.modified)
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get one data source in an array
+                    const dataSource = res.body;
+                    expect(dataSource).toBeDefined();
+                    expect(dataSource.stix).toBeDefined();
+                    expect(dataSource.stix.id).toBe(dataSource2.stix.id);
+                    expect(dataSource.stix.modified).toBe(dataSource2.stix.modified);
+                    done();
+                }
+            });
+    });
+
+    it('DELETE /api/data-sources deletes a data source', function (done) {
+        request(app)
+            .delete('/api/data-sources/' + dataSource1.stix.id + '/modified/' + dataSource1.stix.modified)
+            .expect(204)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    done();
+                }
+            });
+    });
+
+    it('DELETE /api/data-sources should delete the second data source', function (done) {
+        request(app)
+            .delete('/api/data-sources/' + dataSource2.stix.id + '/modified/' + dataSource2.stix.modified)
+            .expect(204)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/data-sources returns an empty array of data sources', function (done) {
+        request(app)
+            .get('/api/data-sources')
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get an empty array
+                    const dataSources = res.body;
+                    expect(dataSources).toBeDefined();
+                    expect(Array.isArray(dataSources)).toBe(true);
+                    expect(dataSources.length).toBe(0);
+                    done();
+                }
+            });
+    });
+
+    after(async function() {
+        await database.closeConnection();
+    });
+});
+

--- a/app/tests/import/collection-bundles-enterprise.spec.js
+++ b/app/tests/import/collection-bundles-enterprise.spec.js
@@ -18,6 +18,7 @@ describe('Collection Bundles API Full-Size Test', function () {
     let app;
     let collectionBundle72;
     let collectionBundle80;
+    let collectionBundle90;
 
     before(async function() {
         // Establish the database connection
@@ -32,9 +33,31 @@ describe('Collection Bundles API Full-Size Test', function () {
 
         collectionBundle72 = await readJson('./enterprise-attack-7.2.json');
         collectionBundle80 = await readJson('./enterprise-attack-8.0.json');
+        collectionBundle90 = await readJson('./enterprise-attack-9.0-with-mock-data-sources-collection.json');
     });
 
-    it('POST /api/collection-bundles previews the import of a collection bundle (checkOnly)', function (done) {
+    it('POST /api/collection-bundles previews the import of a 9.0 collection bundle (checkOnly)', function (done) {
+        const body = collectionBundle90;
+        request(app)
+            .post('/api/collection-bundles?checkOnly=true')
+            .send(body)
+            .set('Accept', 'application/json')
+            .expect(201)
+            .expect('Content-Type', /json/)
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    // We expect to get the created collection object
+                    const collection = res.body;
+                    expect(collection).toBeDefined();
+                    expect(collection.workspace.import_categories.errors.length).toBe(0);
+                    done();
+                }
+            });
+    });
+
+    it('POST /api/collection-bundles previews the import of a 8.0 collection bundle (checkOnly)', function (done) {
         const body = collectionBundle80;
         request(app)
             .post('/api/collection-bundles?checkOnly=true')
@@ -55,7 +78,7 @@ describe('Collection Bundles API Full-Size Test', function () {
             });
     });
 
-    it('POST /api/collection-bundles previews the import of a collection bundle (previewOnly)', function (done) {
+    it('POST /api/collection-bundles previews the import of a 8.0 collection bundle (previewOnly)', function (done) {
         const body = collectionBundle80;
         request(app)
             .post('/api/collection-bundles?previewOnly=true')
@@ -95,6 +118,36 @@ describe('Collection Bundles API Full-Size Test', function () {
                     if (collection.workspace.import_categories.errors.length > 0) {
                         console.log(collection.workspace.import_categories.errors[0]);
                     }
+                    expect(collection.workspace.import_categories.errors.length).toBe(0);
+                    console.log(`references, additions: ${ collection.workspace.import_references.additions.length }`);
+                    console.log(`references, changes: ${ collection.workspace.import_references.changes.length }`);
+
+                    console.log(`categories, revocations: ${ collection.workspace.import_categories.revocations.length }`);
+                    console.log(`categories, deprecations: ${ collection.workspace.import_categories.deprecations.length }`);
+                    done();
+                }
+            });
+    });
+
+    it('POST /api/collection-bundles imports the 9.0 enterprise collection bundle', function (done) {
+        this.timeout(60000);
+        const body = collectionBundle90;
+        request(app)
+            .post('/api/collection-bundles')
+            .send(body)
+            .set('Accept', 'application/json')
+            .expect(201)
+            .expect('Content-Type', /json/)
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    // We expect to get the created collection object
+                    const collection = res.body;
+                    expect(collection).toBeDefined();
+
+                    console.log(JSON.stringify(collection.workspace.import_categories.errors, null, 2));
+
                     expect(collection.workspace.import_categories.errors.length).toBe(0);
                     console.log(`references, additions: ${ collection.workspace.import_references.additions.length }`);
                     console.log(`references, changes: ${ collection.workspace.import_references.changes.length }`);

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -10,6 +10,7 @@ The ATT&CK Workbench database supports the following ATT&CK object types
 - Mitigation (course-of-action)
 - Tactic (x-mitre-tactic)
 - Data Source (x-mitre-data-source)
+- Data Component (x-mitre-data-component)
 - Identity (identity)
 - Marking Definition (marking-definition)
 - Relationship (relationship)

--- a/scripts/clearDatabase.js
+++ b/scripts/clearDatabase.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const AttackObject = require('../app/models/attack-object-model');
+const Reference = require('../app/models/reference-model');
+
+async function clearDatabase() {
+    // Establish the database connection
+    console.log('Setting up the database connection');
+    await require('../app/lib/database-connection').initializeConnection();
+
+    let result = await AttackObject.deleteMany();
+    console.log(`Deleted ${ result.deletedCount } objects from the attackObjects collection.`);
+
+    result = await Reference.deleteMany();
+    console.log(`Deleted ${ result.deletedCount } objects from the references collection.`);
+}
+
+clearDatabase();

--- a/scripts/loadBundle.js
+++ b/scripts/loadBundle.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const collectionBundleService = require('../app/services/collection-bundles-service');
+const { promises: fs } = require("fs");
+
+async function readJson(path) {
+    const filePath = require.resolve(path);
+    const data = await fs.readFile(filePath);
+    return JSON.parse(data);
+}
+
+async function loadBundle() {
+    // Establish the database connection
+    console.log('Setting up the database connection');
+    await require('../app/lib/database-connection').initializeConnection();
+
+    const bundle = await readJson('../app/tests/import/enterprise-attack-9.0-with-mock-data-sources-collection.json');
+    const options = {};
+
+    // Find the x-mitre-collection objects
+    const collections = bundle.objects.filter(object => object.type === 'x-mitre-collection');
+
+    // The bundle must have an x-mitre-collection object
+    if (collections.length === 0) {
+        console.warn("Unable to import collection bundle. Missing x-mitre-collection object.");
+        throw(new Error('Unable to import collection bundle. Missing x-mitre-collection object.'));
+    }
+    else if (collections.length > 1) {
+        console.warn("Unable to import collection bundle. More than one x-mitre-collection object.");
+        throw(new Error('Unable to import collection bundle. More than one x-mitre-collection object.'));
+
+    }
+
+    // The collection must have an id.
+    if (!collections[0].id) {
+        console.warn('Unable to import collection bundle. x-mitre-collection missing id');
+        throw(new Error('Unable to import collection bundle. x-mitre-collection missing id'));
+    }
+
+    console.log('Importing bundle into database...')
+    collectionBundleService.importBundle(collections[0], bundle, options, function(err, importedCollection) {
+        if (err) {
+            throw err;
+        }
+        else {
+            console.log('Bundle imported');
+        }
+    });
+}
+
+loadBundle();


### PR DESCRIPTION
Adds endpoints for data sources and data components.
```
GET /api/data-sources
POST /api/data-sources
GET /api/data-sources/{stidId}
GET /api/data-sources/{stidId}/modified/{modified)
PUT /api/data-sources/{stidId}/modified/{modified)
DELETE /api/data-sources/{stidId}/modified/{modified)
```

```
GET /api/data-components
POST /api/data-components
GET /api/data-components/{stidId}
GET /api/data-components/{stidId}/modified/{modified)
PUT /api/data-components/{stidId}/modified/{modified)
DELETE /api/data-components/{stidId}/modified/{modified)
```

Updates the import collection endpoint to also import data sources and data components.

Minor bump of Mongoose module version to remove security warning.