### PR TITLE
Make spec_version optional when importing a collection bundle plus logging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Note that any values set in a configuration file take precedence over values set
 | **DATABASE_URL**            | yes      | none          | URL of the MongoDB server                                          |
 | **DEFAULT_INTERVAL**        | no       | `300`         | How often collection indexes should check for updates (in seconds) |
 | **JSON_CONFIG_PATH**        | no       | ``            | Location of a JSON file containing configuration values            |
-
+| **LOG_LEVEL**               | no       | `info`        | Level of messages to be written to the log (error, warn, http, info, verbose, debug) |
 
 A typical value for DATABASE_URL when running on a development machine is `mongodb://localhost/attack-workspace`.
 This assumes that a MongoDB server is running on the same machine and is listening on the standard port of 27017.
@@ -96,6 +96,7 @@ If the `JSON_CONFIG_PATH` environment variable is set, the app will also read co
 | **app.env**                         | string   | NODE_ENV                           |
 | **database.url**                    | string   | DATABASE_URL                       |
 | **collectionIndex.defaultInterval** | int      | DEFAULT_INTERVAL                   |
+| **logging.logLevel**                | string   | LOG_LEVEL                          |
 
 Sample configuration file setting the server port and database url:
 
@@ -152,15 +153,6 @@ to run the Snyk validator on the currently installed modules.
 This will check the modules for known security flaws.
 
 Note that this requires the `SNYK_TOKEN` environment variable to be set to a valid Snyk token to run.
-
-### Generate REST API Documentation
-
-In addition to the Swagger UI that is available when the app is running, a static set of files describing the REST API can be generated.
-Use the command:
-
-`npm run api:generate-all`
-
-to generate the set of static HTML files that document the REST API.
 
 ## Github Workflow
 

--- a/app/api/definitions/components/collection-bundles.yml
+++ b/app/api/definitions/components/collection-bundles.yml
@@ -5,7 +5,6 @@ components:
       required:
         - id
         - type
-        - spec_version
         - objects
       properties:
         id:

--- a/app/config/config.js
+++ b/app/config/config.js
@@ -33,6 +33,13 @@ const config = convict({
             env: 'DATABASE_URL'
         }
     },
+    logging: {
+        logLevel: {
+            doc: 'Level of logging messages to write to console (error, warn, http, info, verbose, debug)',
+            default: 'info',
+            env: 'LOG_LEVEL'
+        }
+    },
     openApi: {
         specPath: {
             default: './app/api/definitions/openapi.yml'

--- a/app/lib/logger.js
+++ b/app/lib/logger.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const winston = require('winston');
+const config = require('../config/config');
 
 const consoleFormat = winston.format.combine(
     winston.format.timestamp(),
@@ -19,7 +20,7 @@ const logLevels = {
 const logger = winston.createLogger({
     format: consoleFormat,
     transports: [
-        new winston.transports.Console()
+        new winston.transports.Console({ level: config.logging.logLevel })
     ],
     levels: logLevels
 });

--- a/app/services/collection-bundles-service.js
+++ b/app/services/collection-bundles-service.js
@@ -17,6 +17,8 @@ const referencesService = require('../services/references-service');
 const dataSourcesService = require('../services/data-sources-service');
 const dataComponentsService = require('../services/data-components-service');
 
+const logger = require('../lib/logger');
+
 const async = require('async');
 
 const errors = {
@@ -159,8 +161,10 @@ exports.importBundle = function(collection, data, options, callback) {
                             const importError = {
                                 object_ref: importObject.id,
                                 object_modified: importObject.modified,
-                                error_type: importErrors.notInContents
+                                error_type: importErrors.notInContents,
+                                error_message: `Warning: Object in bundle but not in x_mitre_contents. Object will be saved in database.`
                             }
+                            logger.verbose(`Import Bundle Warning: Object not in x_mitre_contents. id = ${ importObject.id }, modified = ${ importObject.modified }`);
                             importedCollection.workspace.import_categories.errors.push(importError);
                         }
 
@@ -212,6 +216,7 @@ exports.importBundle = function(collection, data, options, callback) {
                                         object_modified: importObject.modified,
                                         error_type: importErrors.retrievalError
                                     }
+                                    logger.verbose(`Import Bundle Error: Unable to retrieve objects with matching STIX id. id = ${ importObject.id }, modified = ${ importObject.modified }`);
                                     importedCollection.workspace.import_categories.errors.push(importError);
                                     return callback2a();
                                 }
@@ -351,6 +356,7 @@ exports.importBundle = function(collection, data, options, callback) {
                                                                 error_type: importErrors.saveError,
                                                                 error_message: err.message
                                                             }
+                                                            logger.verbose(`Import Bundle Error: Unable to save object. id = ${ importObject.id }, modified = ${ importObject.modified }, ${ err.message }`);
                                                             importedCollection.workspace.import_categories.errors.push(importError);
                                                             return callback2a();
                                                         }
@@ -370,6 +376,7 @@ exports.importBundle = function(collection, data, options, callback) {
                                                                 error_type: importErrors.saveError,
                                                                 error_message: err.message
                                                             }
+                                                            logger.verbose(`Import Bundle Error: Unable to save object. id = ${ importObject.id }, modified = ${ importObject.modified }, ${ err.message }`);
                                                             importedCollection.workspace.import_categories.errors.push(importError);
                                                             return callback2a();
                                                         }
@@ -394,8 +401,10 @@ exports.importBundle = function(collection, data, options, callback) {
                                 const importError = {
                                     object_ref: importObject.id,
                                     object_modified: importObject.modified,
-                                    error_type: importErrors.unknownObjectType
+                                    error_type: importErrors.unknownObjectType,
+                                    error_message: `Unknown object type: ${ importObject.type }`
                                 }
+                                logger.verbose(`Import Bundle Error: Unknown object type. id = ${ importObject.id }, modified = ${ importObject.modified }, type = ${ importObject.type }`);
                                 importedCollection.workspace.import_categories.errors.push(importError);
                                 return callback2a();
                             }
@@ -408,8 +417,10 @@ exports.importBundle = function(collection, data, options, callback) {
                             const importError = {
                                 object_ref: entry.object_ref,
                                 object_modified: entry.object_modified,
-                                error_type: importErrors.missingObject
+                                error_type: importErrors.missingObject,
+                                error_message: 'Object listed in x_mitre_contents, but not in bundle'
                             }
+                            logger.verbose(`Import Bundle Error: Object in x_mitre_contents but not in bundle. id = ${ entry.object_ref }, modified = ${ entry.object_modified }`);
                             importedCollection.workspace.import_categories.errors.push(importError);
                         }
 

--- a/app/tests/api/collection-bundles/collection-bundles.spec.js
+++ b/app/tests/api/collection-bundles/collection-bundles.spec.js
@@ -39,6 +39,10 @@ const collectionBundleData = {
                     "object_modified": "2019-02-03T16:56:41.200Z"
                 },
                 {
+                    "object_ref": "attack-pattern--14fbfb6a-c4d9-4c3b-a7ef-f8df23e3b22b",
+                    "object_modified": "2019-02-22T16:56:41.200Z",
+                },
+                {
                     "object_ref": "not-a-type--a29c7d3a-3836-4219-b3db-ff946ea2251b",
                     "object_modified": "2020-05-30T14:03:43.761Z"
                 },
@@ -93,6 +97,29 @@ const collectionBundleData = {
             spec_version: '2.1',
             type: 'attack-pattern',
             description: 'This is another technique.',
+            external_references: [
+                { source_name: 'source-1', external_id: 's1' },
+                { source_name: 'attack-pattern-2 source', description: 'this is a source description 2'}
+            ],
+            object_marking_refs: [ 'marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168' ],
+            created_by_ref: "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+            kill_chain_phases: [
+                { kill_chain_name: 'kill-chain-name-1', phase_name: 'phase-1' }
+            ],
+            x_mitre_data_sources: [ 'data-source-1', 'data-source-2' ],
+            x_mitre_detection: 'detection text',
+            x_mitre_is_subtechnique: false,
+            x_mitre_impact_type: [ 'impact-1' ],
+            x_mitre_platforms: [ 'platform-1', 'platform-2' ]
+        },
+        {
+            id: 'attack-pattern--14fbfb6a-c4d9-4c3b-a7ef-f8df23e3b22b',
+            created: '2019-02-22T16:56:41.200Z',
+            modified: '2019-02-22T16:56:41.200Z',
+            name: 'attack-pattern-2',
+            x_mitre_version: '1.0',
+            type: 'attack-pattern',
+            description: 'This is technique that is missing a spec_version.',
             external_references: [
                 { source_name: 'source-1', external_id: 's1' },
                 { source_name: 'attack-pattern-2 source', description: 'this is a source description 2'}
@@ -434,7 +461,7 @@ describe('Collection Bundles Basic API', function () {
                     // We expect to get the created collection object
                     const collection = res.body;
                     expect(collection).toBeDefined();
-                    expect(collection.workspace.import_categories.additions.length).toBe(6);
+                    expect(collection.workspace.import_categories.additions.length).toBe(7);
                     expect(collection.workspace.import_categories.errors.length).toBe(3);
                     done();
                 }
@@ -457,7 +484,7 @@ describe('Collection Bundles Basic API', function () {
                     // We expect to get the created collection object
                     const collection = res.body;
                     expect(collection).toBeDefined();
-                    expect(collection.workspace.import_categories.additions.length).toBe(6);
+                    expect(collection.workspace.import_categories.additions.length).toBe(7);
                     expect(collection.workspace.import_categories.errors.length).toBe(3);
                     done();
                 }
@@ -479,8 +506,8 @@ describe('Collection Bundles Basic API', function () {
                     // We expect to get the created collection object
                     collection1 = res.body;
                     expect(collection1).toBeDefined();
-                    expect(collection1.workspace.import_categories.additions.length).toBe(6);
-                    expect(collection1.workspace.import_categories.errors.length).toBe(3);
+                    expect(collection1.workspace.import_categories.additions.length).toBe(7);
+                    expect(collection1.workspace.import_categories.errors.length).toBe(4);
                     done();
                 }
             });
@@ -542,7 +569,7 @@ describe('Collection Bundles Basic API', function () {
                     expect(collection2).toBeDefined();
                     expect(collection2.workspace.import_categories.changes.length).toBe(1);
                     expect(collection2.workspace.import_categories.duplicates.length).toBe(5);
-                    expect(collection2.workspace.import_categories.errors.length).toBe(3);
+                    expect(collection2.workspace.import_categories.errors.length).toBe(4);
                     done();
                 }
             });
@@ -694,6 +721,7 @@ describe('Collection Bundles Basic API', function () {
             });
     });
 
+    let exportedCollectionBundle;
     it('GET /api/collection-bundles exports the collection bundle with id and modified', function (done) {
         request(app)
             .get(`/api/collection-bundles?collectionId=${ collectionId }&collectionModified=${ encodeURIComponent(collectionTimestamp) }`)
@@ -706,11 +734,39 @@ describe('Collection Bundles Basic API', function () {
                 }
                 else {
                     // We expect to get the exported collection bundle
-                    const collectionBundle = res.body;
-                    expect(collectionBundle).toBeDefined();
-                    expect(Array.isArray(collectionBundle.objects)).toBe(true);
-                    expect(collectionBundle.objects.length).toBe(6);
+                    exportedCollectionBundle = res.body;
+                    expect(exportedCollectionBundle).toBeDefined();
+                    expect(Array.isArray(exportedCollectionBundle.objects)).toBe(true);
+                    expect(exportedCollectionBundle.objects.length).toBe(6);
 
+                    done();
+                }
+            });
+    });
+
+    it('POST /api/collection-bundles imports the previously exported collection bundle', function (done) {
+        // Update the exported collection bundle so it isn't a duplicate
+        const updateTimestamp = new Date().toISOString();
+        const updatedCollection = _.cloneDeep(exportedCollectionBundle);
+        updatedCollection.objects[0].modified = updateTimestamp;
+        updatedCollection.objects[0].x_mitre_contents[0].object_modified = updateTimestamp;
+        updatedCollection.objects[1].modified = updateTimestamp;
+        updatedCollection.objects[1].x_mitre_version = '1.1';
+
+        const body = updatedCollection;
+        request(app)
+            .post('/api/collection-bundles')
+            .send(body)
+            .set('Accept', 'application/json')
+            .expect(201)
+            .expect('Content-Type', /json/)
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    // We expect to get the created collection object
+                    const collection = res.body;
+                    expect(collection).toBeDefined();
                     done();
                 }
             });


### PR DESCRIPTION
Make the `spec_version` optional when importing a collection bundle.
Make the logging level settable using the LOG_LEVEL environment variable.
Improve logging of issues that occur when importing a collection bundle.
Remove some no-longer-applicable documentation about generating REST API documentation.
Add a test that exports a collection bundle and then imports it.