### PR TITLE
Do not set the upgrade-insecure-requests directive on the Content-Security-Policy header

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -2,6 +2,23 @@
 
 let app;
 
+
+/**
+ * Do not set the upgrade-insecure-requests directive on the Content-Security-Policy header
+ * @param {object} app - express app
+ * @param {object} helmet - helmet module
+ */
+function disableUpgradeInsecureRequests(app, helmet) {
+    const defaultDirectives = helmet.contentSecurityPolicy.getDefaultDirectives();
+    delete defaultDirectives['upgrade-insecure-requests'];
+
+    app.use(helmet.contentSecurityPolicy({
+        directives: {
+            ...defaultDirectives,
+        },
+    }));
+}
+
 exports.initializeApp = async function() {
     // Only set up the express app once
     if (app) {
@@ -37,6 +54,7 @@ exports.initializeApp = async function() {
     // Set HTTP response headers
     const helmet = require("helmet");
     app.use(helmet());
+    disableUpgradeInsecureRequests(app, helmet);
 
     // Development Environment
     if (config.app.env === 'development') {


### PR DESCRIPTION
The `upgrade-insecure-requests` directive is set by default by helmet. This directive is intended to be used when migrating systems from HTTP to HTTPS to defer the effort required to modify a large number of URLs that might be embedded in a web site.

That situation doesn't apply to ATT&CK workbench so the directive is not required. Using this directive causes failures in most browsers when attempting to access an instance of the REST API that is using HTTP and running on a server that is not localhost.