### PR TITLE
Add an endpoint for retrieving the system version info

### DIFF
--- a/app/api/definitions/components/system-configuration.yml
+++ b/app/api/definitions/components/system-configuration.yml
@@ -1,5 +1,15 @@
 components:
   schemas:
+    system-version:
+      type: object
+      properties:
+        version:
+          type: string
+          description: Version of the REST API software
+        attackSpecVersion:
+          type: string
+          description: ATT&CK spec version of the REST API software
+
     allowed-values:
       type: object
       properties:

--- a/app/api/definitions/openapi.yml
+++ b/app/api/definitions/openapi.yml
@@ -203,6 +203,9 @@ paths:
     $ref: 'paths/stix-bundles-paths.yml#/paths/~1api~1stix-bundles'
 
   # System Configuration
+  /api/config/system-version:
+    $ref: 'paths/system-configuration-paths.yml#/paths/~1api~1config~1system-version'
+
   /api/config/allowed-values:
     $ref: 'paths/system-configuration-paths.yml#/paths/~1api~1config~1allowed-values'
 

--- a/app/api/definitions/paths/system-configuration-paths.yml
+++ b/app/api/definitions/paths/system-configuration-paths.yml
@@ -1,4 +1,20 @@
 paths:
+  /api/config/system-version:
+    get:
+      summary: 'Get the system version info'
+      operationId: 'config-get-system-version'
+      description: |
+        This endpoint gets the system version info from the package.json file.
+      tags:
+        - 'System Configuration'
+      responses:
+        '200':
+          description: 'System version info'
+          content:
+            application/json:
+              schema:
+                $ref: '../components/system-configuration.yml#/components/schemas/system-version'
+
   /api/config/allowed-values:
     get:
       summary: 'Get the list of domain-specific allowed values'

--- a/app/config/config.js
+++ b/app/config/config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const convict = require('convict');
+const packageJson = require('../../package.json');
 
 const config = convict({
     server: {
@@ -24,6 +25,12 @@ const config = convict({
         env: {
             default: 'development',
             env: 'NODE_ENV'
+        },
+        version: {
+            default: packageJson.version
+        },
+        attackSpecVersion: {
+            default: packageJson.attackSpecVersion
         }
     },
     database: {

--- a/app/controllers/system-configuration-controller.js
+++ b/app/controllers/system-configuration-controller.js
@@ -3,6 +3,18 @@
 const systemConfigurationService = require('../services/system-configuration-service');
 const logger = require('../lib/logger');
 
+exports.retrieveSystemVersion = function(req, res) {
+    try {
+        const systemVersionInfo = systemConfigurationService.retrieveSystemVersion();
+        logger.debug(`Success: Retrieved system version, version: ${ systemVersionInfo.version }, attackSpecVersion: ${ systemVersionInfo.attackSpecVersion }`);
+        return res.status(200).send(systemVersionInfo);
+    }
+    catch(err) {
+        logger.error("Unable to retrieve system version, failed with error: " + err);
+        return res.status(500).send("Unable to retrieve system version. Server error.");
+    }
+};
+
 exports.retrieveAllowedValues = function(req, res) {
     systemConfigurationService.retrieveAllowedValues(function(err, allowedValues) {
         if (err) {

--- a/app/routes/system-configuration-routes.js
+++ b/app/routes/system-configuration-routes.js
@@ -5,6 +5,9 @@ const systemConfigurationController = require('../controllers/system-configurati
 
 const router = express.Router();
 
+router.route('/config/system-version')
+    .get(systemConfigurationController.retrieveSystemVersion);
+
 router.route('/config/allowed-values')
     .get(systemConfigurationController.retrieveAllowedValues);
 

--- a/app/services/system-configuration-service.js
+++ b/app/services/system-configuration-service.js
@@ -14,6 +14,15 @@ const errors = {
 };
 exports.errors = errors;
 
+exports.retrieveSystemVersion = function() {
+    const systemVersionInfo = {
+        version: config.app.version,
+        attackSpecVersion: config.app.attackSpecVersion
+    };
+
+    return systemVersionInfo;
+}
+
 exports.retrieveAllowedValues = function(callback) {
     if (allowedValues) {
         // Return existing object asynchronously

--- a/app/tests/api/system-configuration/system-configuration.spec.js
+++ b/app/tests/api/system-configuration/system-configuration.spec.js
@@ -22,6 +22,28 @@ describe('System Configuration API', function () {
         app = await require('../../../index').initializeApp();
     });
 
+    it('GET /api/config/system-version returns the system version info', function (done) {
+        request(app)
+            .get('/api/config/system-version')
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get the system version info
+                    const systemVersionInfo = res.body;
+                    expect(systemVersionInfo).toBeDefined();
+                    expect(systemVersionInfo.version).toBeDefined();
+                    expect(systemVersionInfo.attackSpecVersion).toBeDefined();
+
+                    done();
+                }
+            });
+    });
+
     it('GET /api/config/allowed-values returns the allowed values', function (done) {
         request(app)
             .get('/api/config/allowed-values')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "attack-workbench-rest-api",
-  "version": "1.0.1",
+  "version": "1.1.0",
+  "attackSpecVersion": "2.1.0",
   "description": "An application allowing users to explore, create, annotate, and share extensions of the MITRE ATT&CK® knowledge base. This repository contains the REST API service for storing, querying, and editing ATT&CK objects.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add endpoint for retrieving the system version info.
Add attackSpecVersion to the package.json file.
Make version and attackSpecVersion available in the config object (pulled from package.json).
Add test for new endpoint.
Also bumps app version number for upcoming release.