### PR TITLE
Add x_mitre_attack_spec_version to all ATT&CK objects

### DIFF
--- a/app/api/definitions/components/collections.yml
+++ b/app/api/definitions/components/collections.yml
@@ -95,6 +95,9 @@ components:
             x_mitre_version:
               type: string
               example: '1.0'
+            x_mitre_attack_spec_version:
+              type: string
+              example: '2.1.0'
 
     x-mitre-contents:
       type: object

--- a/app/api/definitions/components/data-components.yml
+++ b/app/api/definitions/components/data-components.yml
@@ -42,3 +42,6 @@ components:
             x_mitre_version:
               type: string
               example: '1.0'
+            x_mitre_attack_spec_version:
+              type: string
+              example: '2.1.0'

--- a/app/api/definitions/components/data-sources.yml
+++ b/app/api/definitions/components/data-sources.yml
@@ -48,6 +48,9 @@ components:
             x_mitre_version:
               type: string
               example: '1.0'
+            x_mitre_attack_spec_version:
+              type: string
+              example: '2.1.0'
             x_mitre_collection_layers:
               type: array
               items:

--- a/app/api/definitions/components/groups.yml
+++ b/app/api/definitions/components/groups.yml
@@ -47,3 +47,6 @@ components:
             x_mitre_version:
               type: string
               example: '1.0'
+            x_mitre_attack_spec_version:
+              type: string
+              example: '2.1.0'

--- a/app/api/definitions/components/identities.yml
+++ b/app/api/definitions/components/identities.yml
@@ -48,3 +48,6 @@ components:
             x_mitre_version:
               type: string
               example: '1.0'
+            x_mitre_attack_spec_version:
+              type: string
+              example: '2.1.0'

--- a/app/api/definitions/components/marking-definitions.yml
+++ b/app/api/definitions/components/marking-definitions.yml
@@ -28,6 +28,9 @@ components:
             x_mitre_deprecated:
               type: boolean
               example: false
+            x_mitre_attack_spec_version:
+              type: string
+              example: '2.1.0'
 
     marking-object-definition:
       type: object

--- a/app/api/definitions/components/matrices.yml
+++ b/app/api/definitions/components/matrices.yml
@@ -43,3 +43,6 @@ components:
             x_mitre_version:
               type: string
               example: '1.0'
+            x_mitre_attack_spec_version:
+              type: string
+              example: '2.1.0'

--- a/app/api/definitions/components/mitigations.yml
+++ b/app/api/definitions/components/mitigations.yml
@@ -39,3 +39,6 @@ components:
             x_mitre_version:
               type: string
               example: '1.0'
+            x_mitre_attack_spec_version:
+              type: string
+              example: '2.1.0'

--- a/app/api/definitions/components/notes.yml
+++ b/app/api/definitions/components/notes.yml
@@ -39,3 +39,6 @@ components:
             x_mitre_deprecated:
               type: boolean
               example: false
+            x_mitre_attack_spec_version:
+              type: string
+              example: '2.1.0'

--- a/app/api/definitions/components/relationships.yml
+++ b/app/api/definitions/components/relationships.yml
@@ -51,3 +51,6 @@ components:
             x_mitre_version:
               type: string
               example: '1.0'
+            x_mitre_attack_spec_version:
+              type: string
+              example: '2.1.0'

--- a/app/api/definitions/components/software.yml
+++ b/app/api/definitions/components/software.yml
@@ -49,6 +49,9 @@ components:
             x_mitre_version:
               type: string
               example: '1.0'
+            x_mitre_attack_spec_version:
+              type: string
+              example: '2.1.0'
             x_mitre_platforms:
               type: array
               items:

--- a/app/api/definitions/components/tactics.yml
+++ b/app/api/definitions/components/tactics.yml
@@ -43,3 +43,6 @@ components:
             x_mitre_version:
               type: string
               example: '1.0'
+            x_mitre_attack_spec_version:
+              type: string
+              example: '2.1.0'

--- a/app/api/definitions/components/techniques.yml
+++ b/app/api/definitions/components/techniques.yml
@@ -79,6 +79,9 @@ components:
             x_mitre_version:
               type: string
               example: '1.0'
+            x_mitre_attack_spec_version:
+              type: string
+              example: '2.1.0'
 
     kill_chain_phase:
       type: object

--- a/app/models/collection-model.js
+++ b/app/models/collection-model.js
@@ -19,7 +19,8 @@ const xMitreCollection = {
     x_mitre_contents: [ xMitreContentSchema ],
     x_mitre_deprecated: Boolean,
     x_mitre_domains: [ String ],
-    x_mitre_version: String
+    x_mitre_version: String,
+    x_mitre_attack_spec_version: String
 };
 
 // Create the definition

--- a/app/models/data-component-model.js
+++ b/app/models/data-component-model.js
@@ -14,7 +14,8 @@ const stixDataComponent = {
     x_mitre_modified_by_ref: String,
     x_mitre_deprecated: Boolean,
     x_mitre_domains: [ String ],
-    x_mitre_version: String
+    x_mitre_version: String,
+    x_mitre_attack_spec_version: String
 };
 
 // Create the definition

--- a/app/models/data-source-model.js
+++ b/app/models/data-source-model.js
@@ -15,6 +15,7 @@ const stixDataSource = {
     x_mitre_deprecated: Boolean,
     x_mitre_domains: [ String ],
     x_mitre_version: String,
+    x_mitre_attack_spec_version: String,
     x_mitre_contributors: [ String ],
     x_mitre_collection_layers: [ String ]
 };

--- a/app/models/group-model.js
+++ b/app/models/group-model.js
@@ -15,6 +15,7 @@ const stixIntrusionSet = {
     x_mitre_deprecated: Boolean,
     x_mitre_domains: [ String ],
     x_mitre_version: String,
+    x_mitre_attack_spec_version: String,
     x_mitre_contributors: [ String ]
 };
 

--- a/app/models/identity-model.js
+++ b/app/models/identity-model.js
@@ -16,7 +16,8 @@ const identityProperties = {
     // ATT&CK custom stix properties
     x_mitre_modified_by_ref: String,
     x_mitre_deprecated: Boolean,
-    x_mitre_version: String
+    x_mitre_version: String,
+    x_mitre_attack_spec_version: String
 };
 
 // Create the definition

--- a/app/models/marking-definition-model.js
+++ b/app/models/marking-definition-model.js
@@ -16,7 +16,8 @@ const markingDefinitionProperties = {
     definition: markingObject,
 
     // ATT&CK custom stix properties
-    x_mitre_deprecated: Boolean
+    x_mitre_deprecated: Boolean,
+    x_mitre_attack_spec_version: String
 };
 
 // Create the definition

--- a/app/models/matrix-model.js
+++ b/app/models/matrix-model.js
@@ -14,7 +14,8 @@ const matrixProperties = {
     x_mitre_modified_by_ref: String,
     x_mitre_deprecated: Boolean,
     x_mitre_domains: [ String ],
-    x_mitre_version: String
+    x_mitre_version: String,
+    x_mitre_attack_spec_version: String
 };
 
 // Create the definition

--- a/app/models/mitigation-model.js
+++ b/app/models/mitigation-model.js
@@ -13,7 +13,8 @@ const stixCourseOfAction = {
     x_mitre_modified_by_ref: String,
     x_mitre_deprecated: Boolean,
     x_mitre_domains: [ String ],
-    x_mitre_version: String
+    x_mitre_version: String,
+    x_mitre_attack_spec_version: String
 };
 
 // Create the definition

--- a/app/models/note-model.js
+++ b/app/models/note-model.js
@@ -13,7 +13,8 @@ const noteProperties = {
 
     // ATT&CK custom stix properties
     x_mitre_modified_by_ref: String,
-    x_mitre_deprecated: Boolean
+    x_mitre_deprecated: Boolean,
+    x_mitre_attack_spec_version: String
 };
 
 // Create the definition

--- a/app/models/relationship-model.js
+++ b/app/models/relationship-model.js
@@ -18,7 +18,8 @@ const relationshipProperties = {
     x_mitre_modified_by_ref: String,
     x_mitre_deprecated: Boolean,
     x_mitre_domains: [ String ],
-    x_mitre_version: String
+    x_mitre_version: String,
+    x_mitre_attack_spec_version: String
 };
 
 // Create the definition

--- a/app/models/software-model.js
+++ b/app/models/software-model.js
@@ -17,6 +17,7 @@ const stixMalware = {
     x_mitre_deprecated: Boolean,
     x_mitre_domains: [ String ],
     x_mitre_version: String,
+    x_mitre_attack_spec_version: String,
     x_mitre_contributors: [ String ],
     x_mitre_aliases: [ String ],
 };

--- a/app/models/subschemas/attack-pattern.js
+++ b/app/models/subschemas/attack-pattern.js
@@ -17,6 +17,7 @@ module.exports.attackPattern = {
     x_mitre_deprecated: Boolean,
     x_mitre_domains: [ String ],
     x_mitre_version: String,
+    x_mitre_attack_spec_version: String,
     x_mitre_contributors: [ String ]
 };
 

--- a/app/models/tactic-model.js
+++ b/app/models/tactic-model.js
@@ -14,6 +14,7 @@ const stixTactic = {
     x_mitre_deprecated: Boolean,
     x_mitre_domains: [ String ],
     x_mitre_version: String,
+    x_mitre_attack_spec_version: String,
     x_mitre_contributors: [ String ],
     x_mitre_shortname: String
 };

--- a/app/services/collections-service.js
+++ b/app/services/collections-service.js
@@ -8,6 +8,7 @@ const AttackObject = require('../models/attack-object-model');
 const systemConfigurationService = require('./system-configuration-service');
 const attackObjectsService = require('./attack-objects-service');
 const identitiesService = require('./identities-service');
+const config = require('../config/config');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -272,6 +273,9 @@ exports.create = async function(data, options) {
 
     options = options || {};
     if (!options.import) {
+        // Set the ATT&CK Spec Version
+        collection.stix.x_mitre_attack_spec_version = config.app.attackSpecVersion;
+
         // Get the organization identity
         const organizationIdentityRef = await systemConfigurationService.retrieveOrganizationIdentityRef();
 

--- a/app/services/data-components-service.js
+++ b/app/services/data-components-service.js
@@ -4,6 +4,7 @@ const uuid = require('uuid');
 const DataComponent = require('../models/data-component-model');
 const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
+const config = require('../config/config');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -296,6 +297,9 @@ exports.create = async function(data, options) {
 
     options = options || {};
     if (!options.import) {
+        // Set the ATT&CK Spec Version
+        dataComponent.stix.x_mitre_attack_spec_version = config.app.attackSpecVersion;
+
         // Get the organization identity
         const organizationIdentityRef = await systemConfigurationService.retrieveOrganizationIdentityRef();
 

--- a/app/services/data-sources-service.js
+++ b/app/services/data-sources-service.js
@@ -5,6 +5,7 @@ const DataSource = require('../models/data-source-model');
 const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
 const dataComponentsService = require('./data-components-service');
+const config = require('../config/config');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -242,6 +243,9 @@ exports.create = async function(data, options) {
 
     options = options || {};
     if (!options.import) {
+        // Set the ATT&CK Spec Version
+        dataSource.stix.x_mitre_attack_spec_version = config.app.attackSpecVersion;
+
         // Get the organization identity
         const organizationIdentityRef = await systemConfigurationService.retrieveOrganizationIdentityRef();
 

--- a/app/services/groups-service.js
+++ b/app/services/groups-service.js
@@ -4,6 +4,7 @@ const uuid = require('uuid');
 const Group = require('../models/group-model');
 const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
+const config = require('../config/config');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -215,6 +216,9 @@ exports.create = async function(data, options) {
 
     options = options || {};
     if (!options.import) {
+        // Set the ATT&CK Spec Version
+        group.stix.x_mitre_attack_spec_version = config.app.attackSpecVersion;
+
         // Get the organization identity
         const organizationIdentityRef = await systemConfigurationService.retrieveOrganizationIdentityRef();
 

--- a/app/services/identities-service.js
+++ b/app/services/identities-service.js
@@ -2,6 +2,7 @@
 
 const uuid = require('uuid');
 const Identity = require('../models/identity-model');
+const config = require('../config/config');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -202,6 +203,9 @@ exports.create = async function(data, options) {
 
     options = options || {};
     if (!options.import) {
+        // Set the ATT&CK Spec Version
+        identity.stix.x_mitre_attack_spec_version = config.app.attackSpecVersion;
+
         // Assign a new STIX id if not already provided
         identity.stix.id = identity.stix.id || `identity--${uuid.v4()}`;
     }

--- a/app/services/marking-definitions-service.js
+++ b/app/services/marking-definitions-service.js
@@ -4,6 +4,7 @@ const uuid = require('uuid');
 const MarkingDefinition = require('../models/marking-definition-model');
 const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
+const config = require('../config/config');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -132,6 +133,9 @@ exports.create = async function(data, options) {
 
     options = options || {};
     if (!options.import) {
+        // Set the ATT&CK Spec Version
+        markingDefinition.stix.x_mitre_attack_spec_version = config.app.attackSpecVersion;
+
         // Get the organization identity
         const organizationIdentityRef = await systemConfigurationService.retrieveOrganizationIdentityRef();
 

--- a/app/services/matrices-service.js
+++ b/app/services/matrices-service.js
@@ -4,6 +4,7 @@ const uuid = require('uuid');
 const Matrix = require('../models/matrix-model');
 const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
+const config = require('../config/config');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -218,6 +219,9 @@ exports.create = async function(data, options) {
 
     options = options || {};
     if (!options.import) {
+        // Set the ATT&CK Spec Version
+        matrix.stix.x_mitre_attack_spec_version = config.app.attackSpecVersion;
+
         // Get the organization identity
         const organizationIdentityRef = await systemConfigurationService.retrieveOrganizationIdentityRef();
 

--- a/app/services/mitigations-service.js
+++ b/app/services/mitigations-service.js
@@ -4,6 +4,7 @@ const uuid = require('uuid');
 const Mitigation = require('../models/mitigation-model');
 const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
+const config = require('../config/config');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -216,6 +217,9 @@ exports.create = async function(data, options) {
 
     options = options || {};
     if (!options.import) {
+        // Set the ATT&CK Spec Version
+        mitigation.stix.x_mitre_attack_spec_version = config.app.attackSpecVersion;
+
         // Get the organization identity
         const organizationIdentityRef = await systemConfigurationService.retrieveOrganizationIdentityRef();
 

--- a/app/services/notes-service.js
+++ b/app/services/notes-service.js
@@ -4,6 +4,7 @@ const uuid = require('uuid');
 const Note = require('../models/note-model');
 const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
+const config = require('../config/config');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -215,6 +216,9 @@ exports.create = async function(data, options) {
 
     options = options || {};
     if (!options.import) {
+        // Set the ATT&CK Spec Version
+        note.stix.x_mitre_attack_spec_version = config.app.attackSpecVersion;
+
         // Get the organization identity
         const organizationIdentityRef = await systemConfigurationService.retrieveOrganizationIdentityRef();
 

--- a/app/services/relationships-service.js
+++ b/app/services/relationships-service.js
@@ -4,6 +4,7 @@ const uuid = require('uuid');
 const Relationship = require('../models/relationship-model');
 const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
+const config = require('../config/config');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -278,6 +279,9 @@ exports.create = async function(data, options) {
 
     options = options || {};
     if (!options.import) {
+        // Set the ATT&CK Spec Version
+        relationship.stix.x_mitre_attack_spec_version = config.app.attackSpecVersion;
+
         // Get the organization identity
         const organizationIdentityRef = await systemConfigurationService.retrieveOrganizationIdentityRef();
 

--- a/app/services/software-service.js
+++ b/app/services/software-service.js
@@ -4,6 +4,7 @@ const uuid = require('uuid');
 const Software = require('../models/software-model');
 const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
+const config = require('../config/config');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -227,6 +228,9 @@ exports.create = async function(data, options) {
 
     options = options || {};
     if (!options.import) {
+        // Set the ATT&CK Spec Version
+        software.stix.x_mitre_attack_spec_version = config.app.attackSpecVersion;
+
         // Get the organization identity
         const organizationIdentityRef = await systemConfigurationService.retrieveOrganizationIdentityRef();
 

--- a/app/services/tactics-service.js
+++ b/app/services/tactics-service.js
@@ -4,6 +4,7 @@ const uuid = require('uuid');
 const Tactic = require('../models/tactic-model');
 const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
+const config = require('../config/config');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -215,6 +216,9 @@ exports.create = async function(data, options) {
 
     options = options || {};
     if (!options.import) {
+        // Set the ATT&CK Spec Version
+        tactic.stix.x_mitre_attack_spec_version = config.app.attackSpecVersion;
+
         // Get the organization identity
         const organizationIdentityRef = await systemConfigurationService.retrieveOrganizationIdentityRef();
 

--- a/app/services/techniques-service.js
+++ b/app/services/techniques-service.js
@@ -4,6 +4,7 @@ const uuid = require('uuid');
 const Technique = require('../models/technique-model');
 const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
+const config = require('../config/config');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -218,6 +219,9 @@ exports.create = async function(data, options) {
 
     options = options || {};
     if (!options.import) {
+        // Set the ATT&CK Spec Version
+        technique.stix.x_mitre_attack_spec_version = config.app.attackSpecVersion;
+
         // Get the organization identity
         const organizationIdentityRef = await systemConfigurationService.retrieveOrganizationIdentityRef();
 

--- a/app/tests/api/collections/collections.spec.js
+++ b/app/tests/api/collections/collections.spec.js
@@ -2,6 +2,8 @@ const request = require('supertest');
 const expect = require('expect');
 const _ = require('lodash');
 
+const config = require('../../../config/config');
+
 const logger = require('../../../lib/logger');
 logger.level = 'debug';
 
@@ -238,6 +240,8 @@ describe('Collections (x-mitre-collection) Basic API', function () {
                     expect(collection1.stix.id).toBeDefined();
                     expect(collection1.stix.created).toBeDefined();
                     expect(collection1.stix.modified).toBeDefined();
+                    expect(collection1.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
+
                     done();
                 }
             });
@@ -303,6 +307,7 @@ describe('Collections (x-mitre-collection) Basic API', function () {
                     expect(collection.stix.spec_version).toBe(collection1.stix.spec_version);
                     expect(collection.stix.object_marking_refs).toEqual(expect.arrayContaining(collection1.stix.object_marking_refs));
                     expect(collection.stix.created_by_ref).toBe(collection1.stix.created_by_ref);
+                    expect(collection.stix.x_mitre_attack_spec_version).toBe(collection1.stix.x_mitre_attack_spec_version);
 
                     expect(collection.contents).toBeUndefined();
 

--- a/app/tests/api/data-components/data-components.spec.js
+++ b/app/tests/api/data-components/data-components.spec.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 const database = require('../../../lib/database-in-memory');
 const databaseConfiguration = require('../../../lib/database-configuration');
 
+const config = require('../../../config/config');
+
 const logger = require('../../../lib/logger');
 logger.level = 'debug';
 
@@ -111,6 +113,8 @@ describe('Data Components API', function () {
                     expect(dataComponent1.stix.id).toBeDefined();
                     expect(dataComponent1.stix.created).toBeDefined();
                     expect(dataComponent1.stix.modified).toBeDefined();
+                    expect(dataComponent1.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
+
                     done();
                 }
             });
@@ -179,6 +183,7 @@ describe('Data Components API', function () {
                     expect(dataComponent.stix.object_marking_refs).toEqual(expect.arrayContaining(dataComponent1.stix.object_marking_refs));
                     expect(dataComponent.stix.created_by_ref).toBe(dataComponent1.stix.created_by_ref);
                     expect(dataComponent.stix.x_mitre_version).toBe(dataComponent1.stix.x_mitre_version);
+                    expect(dataComponent.stix.x_mitre_attack_spec_version).toBe(dataComponent1.stix.x_mitre_attack_spec_version);
 
                     done();
                 }

--- a/app/tests/api/data-sources/data-sources.spec.js
+++ b/app/tests/api/data-sources/data-sources.spec.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 const database = require('../../../lib/database-in-memory');
 const databaseConfiguration = require('../../../lib/database-configuration');
 
+const config = require('../../../config/config');
+
 const dataComponentsService = require('../../../services/data-components-service');
 
 const logger = require('../../../lib/logger');
@@ -170,6 +172,8 @@ describe('Data Sources API', function () {
                     expect(dataSource1.stix.id).toBeDefined();
                     expect(dataSource1.stix.created).toBeDefined();
                     expect(dataSource1.stix.modified).toBeDefined();
+                    expect(dataSource1.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
+
                     done();
                 }
             });
@@ -238,6 +242,7 @@ describe('Data Sources API', function () {
                     expect(dataSource.stix.object_marking_refs).toEqual(expect.arrayContaining(dataSource1.stix.object_marking_refs));
                     expect(dataSource.stix.created_by_ref).toBe(dataSource1.stix.created_by_ref);
                     expect(dataSource.stix.x_mitre_version).toBe(dataSource1.stix.x_mitre_version);
+                    expect(dataSource.stix.x_mitre_attack_spec_version).toBe(dataSource1.stix.x_mitre_attack_spec_version);
 
                     done();
                 }

--- a/app/tests/api/groups/groups.spec.js
+++ b/app/tests/api/groups/groups.spec.js
@@ -6,6 +6,8 @@ const database = require('../../../lib/database-in-memory');
 const databaseConfiguration = require('../../../lib/database-configuration');
 const Group = require('../../../models/group-model');
 
+const config = require('../../../config/config');
+
 const logger = require('../../../lib/logger');
 logger.level = 'debug';
 
@@ -110,6 +112,8 @@ describe('Groups API', function () {
                     expect(group1.stix.id).toBeDefined();
                     expect(group1.stix.created).toBeDefined();
                     expect(group1.stix.modified).toBeDefined();
+                    expect(group1.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
+
                     done();
                 }
             });
@@ -177,6 +181,7 @@ describe('Groups API', function () {
                     expect(group.stix.spec_version).toBe(group1.stix.spec_version);
                     expect(group.stix.object_marking_refs).toEqual(expect.arrayContaining(group1.stix.object_marking_refs));
                     expect(group.stix.created_by_ref).toBe(group1.stix.created_by_ref);
+                    expect(group.stix.x_mitre_attack_spec_version).toBe(group1.stix.x_mitre_attack_spec_version);
 
                     done();
                 }

--- a/app/tests/api/identities/identities.spec.js
+++ b/app/tests/api/identities/identities.spec.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 const database = require('../../../lib/database-in-memory');
 const databaseConfiguration = require('../../../lib/database-configuration');
 
+const config = require('../../../config/config');
+
 const logger = require('../../../lib/logger');
 logger.level = 'debug';
 
@@ -103,6 +105,8 @@ describe('Identity API', function () {
                     expect(identity1.stix.id).toBeDefined();
                     expect(identity1.stix.created).toBeDefined();
                     expect(identity1.stix.modified).toBeDefined();
+                    expect(identity1.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
+
                     done();
                 }
             });
@@ -170,6 +174,7 @@ describe('Identity API', function () {
                     expect(identity.stix.spec_version).toBe(identity1.stix.spec_version);
                     expect(identity.stix.object_marking_refs).toEqual(expect.arrayContaining(identity1.stix.object_marking_refs));
                     expect(identity.stix.created_by_ref).toBe(identity1.stix.created_by_ref);
+                    expect(identity.stix.x_mitre_attack_spec_version).toBe(identity1.stix.x_mitre_attack_spec_version);
 
                     done();
                 }

--- a/app/tests/api/marking-definitions/marking-definitions.spec.js
+++ b/app/tests/api/marking-definitions/marking-definitions.spec.js
@@ -4,6 +4,8 @@ const expect = require('expect');
 const database = require('../../../lib/database-in-memory');
 const databaseConfiguration = require('../../../lib/database-configuration');
 
+const config = require('../../../config/config');
+
 const logger = require('../../../lib/logger');
 logger.level = 'debug';
 
@@ -100,6 +102,8 @@ describe('Marking Definitions API', function () {
                     expect(markingDefinition1.stix.id).toBeDefined();
                     expect(markingDefinition1.stix.created).toBeDefined();
                     // stix.modified does not exist for marking definitions
+                    expect(markingDefinition1.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
+
                     done();
                 }
             });
@@ -167,6 +171,7 @@ describe('Marking Definitions API', function () {
                     expect(markingDefinition.stix.spec_version).toBe(markingDefinition1.stix.spec_version);
                     expect(markingDefinition.stix.object_marking_refs).toEqual(expect.arrayContaining(markingDefinition1.stix.object_marking_refs));
                     expect(markingDefinition.stix.created_by_ref).toBe(markingDefinition1.stix.created_by_ref);
+                    expect(markingDefinition.stix.x_mitre_attack_spec_version).toBe(markingDefinition1.stix.x_mitre_attack_spec_version);
 
                     done();
                 }

--- a/app/tests/api/matrices/matrices.spec.js
+++ b/app/tests/api/matrices/matrices.spec.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 const database = require('../../../lib/database-in-memory');
 const databaseConfiguration = require('../../../lib/database-configuration');
 
+const config = require('../../../config/config');
+
 const logger = require('../../../lib/logger');
 logger.level = 'debug';
 
@@ -112,6 +114,8 @@ describe('Matrices API', function () {
                     expect(matrix1.stix.id).toBeDefined();
                     expect(matrix1.stix.created).toBeDefined();
                     expect(matrix1.stix.modified).toBeDefined();
+                    expect(matrix1.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
+
                     done();
                 }
             });
@@ -181,6 +185,7 @@ describe('Matrices API', function () {
                     expect(matrix.stix.spec_version).toBe(matrix1.stix.spec_version);
                     expect(matrix.stix.object_marking_refs).toEqual(expect.arrayContaining(matrix1.stix.object_marking_refs));
                     expect(matrix.stix.created_by_ref).toBe(matrix1.stix.created_by_ref);
+                    expect(matrix.stix.x_mitre_attack_spec_version).toBe(matrix1.stix.x_mitre_attack_spec_version);
 
                     done();
                 }

--- a/app/tests/api/mitigations/mitigations.spec.js
+++ b/app/tests/api/mitigations/mitigations.spec.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 const database = require('../../../lib/database-in-memory');
 const databaseConfiguration = require('../../../lib/database-configuration');
 
+const config = require('../../../config/config');
+
 const logger = require('../../../lib/logger');
 logger.level = 'debug';
 
@@ -107,6 +109,8 @@ describe('Mitigations API', function () {
                     expect(mitigation1.stix.id).toBeDefined();
                     expect(mitigation1.stix.created).toBeDefined();
                     expect(mitigation1.stix.modified).toBeDefined();
+                    expect(mitigation1.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
+
                     done();
                 }
             });
@@ -175,6 +179,7 @@ describe('Mitigations API', function () {
                     expect(mitigation.stix.object_marking_refs).toEqual(expect.arrayContaining(mitigation1.stix.object_marking_refs));
                     expect(mitigation.stix.created_by_ref).toBe(mitigation1.stix.created_by_ref);
                     expect(mitigation.stix.x_mitre_version).toBe(mitigation1.stix.x_mitre_version);
+                    expect(mitigation.stix.x_mitre_attack_spec_version).toBe(mitigation1.stix.x_mitre_attack_spec_version);
 
                     done();
                 }

--- a/app/tests/api/notes/notes.spec.js
+++ b/app/tests/api/notes/notes.spec.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 const database = require('../../../lib/database-in-memory');
 const databaseConfiguration = require('../../../lib/database-configuration');
 
+const config = require('../../../config/config');
+
 const logger = require('../../../lib/logger');
 logger.level = 'debug';
 
@@ -111,6 +113,8 @@ describe('Notes API', function () {
                     expect(note1.stix.id).toBeDefined();
                     expect(note1.stix.created).toBeDefined();
                     expect(note1.stix.modified).toBeDefined();
+                    expect(note1.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
+
                     done();
                 }
             });
@@ -178,6 +182,7 @@ describe('Notes API', function () {
                     expect(note.stix.spec_version).toBe(note1.stix.spec_version);
                     expect(note.stix.object_refs).toEqual(expect.arrayContaining(note1.stix.object_refs));
                     expect(note.stix.created_by_ref).toBe(note1.stix.created_by_ref);
+                    expect(note.stix.x_mitre_attack_spec_version).toBe(note1.stix.x_mitre_attack_spec_version);
 
                     done();
                 }

--- a/app/tests/api/relationships/relationships.spec.js
+++ b/app/tests/api/relationships/relationships.spec.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 const database = require('../../../lib/database-in-memory');
 const databaseConfiguration = require('../../../lib/database-configuration');
 
+const config = require('../../../config/config');
+
 const logger = require('../../../lib/logger');
 logger.level = 'debug';
 
@@ -117,6 +119,8 @@ describe('Relationships API', function () {
                     expect(relationship1a.stix.id).toBeDefined();
                     expect(relationship1a.stix.created).toBeDefined();
                     expect(relationship1a.stix.modified).toBeDefined();
+                    expect(relationship1a.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
+
                     done();
                 }
             });
@@ -184,6 +188,7 @@ describe('Relationships API', function () {
                     expect(relationship.stix.spec_version).toBe(relationship1a.stix.spec_version);
                     expect(relationship.stix.object_marking_refs).toEqual(expect.arrayContaining(relationship1a.stix.object_marking_refs));
                     expect(relationship.stix.created_by_ref).toBe(relationship1a.stix.created_by_ref);
+                    expect(relationship.stix.x_mitre_attack_spec_version).toBe(relationship1a.stix.x_mitre_attack_spec_version);
 
                     done();
                 }

--- a/app/tests/api/software/software.spec.js
+++ b/app/tests/api/software/software.spec.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 const database = require('../../../lib/database-in-memory');
 const databaseConfiguration = require('../../../lib/database-configuration');
 
+const config = require('../../../config/config');
+
 const logger = require('../../../lib/logger');
 logger.level = 'debug';
 
@@ -173,6 +175,8 @@ describe('Software API', function () {
                     expect(software1.stix.id).toBeDefined();
                     expect(software1.stix.created).toBeDefined();
                     expect(software1.stix.modified).toBeDefined();
+                    expect(software1.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
+
                     done();
                 }
             });
@@ -245,6 +249,7 @@ describe('Software API', function () {
                     expect(software.stix.x_mitre_aliases).toEqual(expect.arrayContaining(software1.stix.x_mitre_aliases));
                     expect(software.stix.x_mitre_platforms).toEqual(expect.arrayContaining(software1.stix.x_mitre_platforms));
                     expect(software.stix.x_mitre_contributors).toEqual(expect.arrayContaining(software1.stix.x_mitre_contributors));
+                    expect(software.stix.x_mitre_attack_spec_version).toBe(software1.stix.x_mitre_attack_spec_version);
 
                     done();
                 }

--- a/app/tests/api/tactics/tactics.spec.js
+++ b/app/tests/api/tactics/tactics.spec.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 const database = require('../../../lib/database-in-memory');
 const databaseConfiguration = require('../../../lib/database-configuration');
 
+const config = require('../../../config/config');
+
 const logger = require('../../../lib/logger');
 logger.level = 'debug';
 
@@ -108,6 +110,8 @@ describe('Tactics API', function () {
                     expect(tactic1.stix.created_by_ref).toBeDefined();
                     expect(tactic1.stix.x_mitre_modified_by_ref).toBeDefined();
                     expect(tactic1.stix.created_by_ref).toBe(tactic1.stix.x_mitre_modified_by_ref);
+                    expect(tactic1.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
+
                     done();
                 }
             });
@@ -176,6 +180,7 @@ describe('Tactics API', function () {
                     expect(tactic.stix.object_marking_refs).toEqual(expect.arrayContaining(tactic1.stix.object_marking_refs));
                     expect(tactic.stix.created_by_ref).toBe(tactic1.stix.created_by_ref);
                     expect(tactic.stix.x_mitre_modified_by_ref).toBe(tactic1.stix.x_mitre_modified_by_ref);
+                    expect(tactic.stix.x_mitre_attack_spec_version).toBe(tactic1.stix.x_mitre_attack_spec_version);
 
                     expect(tactic.stix.x_mitre_deprecated).not.toBeDefined();
 

--- a/app/tests/api/techniques/techniques.spec.js
+++ b/app/tests/api/techniques/techniques.spec.js
@@ -2,11 +2,13 @@ const request = require('supertest');
 const expect = require('expect');
 const _ = require('lodash');
 
-const logger = require('../../../lib/logger');
-logger.level = 'debug';
-
 const database = require('../../../lib/database-in-memory');
 const databaseConfiguration = require('../../../lib/database-configuration');
+
+const config = require('../../../config/config');
+
+const logger = require('../../../lib/logger');
+logger.level = 'debug';
 
 // modified and created properties will be set before calling REST API
 // stix.id property will be created by REST API
@@ -113,6 +115,8 @@ describe('Techniques Basic API', function () {
                     expect(technique1.stix.id).toBeDefined();
                     expect(technique1.stix.created).toBeDefined();
                     expect(technique1.stix.modified).toBeDefined();
+                    expect(technique1.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
+
                     done();
                 }
             });
@@ -184,6 +188,7 @@ describe('Techniques Basic API', function () {
                     expect(technique.stix.x_mitre_is_subtechnique).toBe(technique1.stix.x_mitre_is_subtechnique);
                     expect(technique.stix.x_mitre_impact_type).toEqual(expect.arrayContaining(technique1.stix.x_mitre_impact_type));
                     expect(technique.stix.x_mitre_platforms).toEqual(expect.arrayContaining(technique1.stix.x_mitre_platforms));
+                    expect(technique.stix.x_mitre_attack_spec_version).toBe(technique1.stix.x_mitre_attack_spec_version);
 
                     expect(technique.stix.x_mitre_deprecated).not.toBeDefined();
                     expect(technique.stix.x_mitre_defense_bypassed).not.toBeDefined();


### PR DESCRIPTION
Add `x_mitre_attack_spec_version` to all ATT&CK objects that are included in collection bundles.
Update openapi spec to include `x_mitre_attack_spec_version`.
Set the `x_mitre_attack_spec_version` when creating objects (but not when importing).
Add tests for `x_mitre_attack_spec_version`.