### PR TITLE
Modify the nyc coverage configuration

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,9 @@
+{
+  "all": true,
+  "include": [
+    "app/**/*.js"
+  ],
+  "exclude": [
+    "app/tests/**/*.js"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "snyk": "snyk test --insecure --fail-on=upgradable",
     "start": "node ./bin/www",
-    "test": "npm run test:openapi && npm run test:config && npm run test:api && npm run test:import",
+    "test": "npm run test:openapi && npm run test:config && npm run test:api",
     "test:api": "mocha  --timeout 10000 --recursive ./app/tests/api",
     "test:config": "mocha  --timeout 10000 --recursive ./app/tests/config",
     "test:import": "mocha  --timeout 10000 --recursive ./app/tests/import",


### PR DESCRIPTION
Configure nyc to include all Javascript files in the `app` directory in coverage reports, but exclude test files.

Also Remove the import test from the list of standard tests.

Closes #139 