### PR TITLE
Add created and modified timestamps to the user account model

### DIFF
--- a/app/api/definitions/components/user-accounts.yml
+++ b/app/api/definitions/components/user-accounts.yml
@@ -19,3 +19,9 @@ components:
           type: string
           enum: [ 'visitor', 'editor', 'admin' ]
           example: 'editor'
+        created:
+          type: string
+          format: date-time
+        modified:
+          type: string
+          format: date-time

--- a/app/models/user-account-model.js
+++ b/app/models/user-account-model.js
@@ -13,7 +13,9 @@ const userAccountDefinition = {
     },
     username: { type: String, required: true },
     status: { type: String, required: true },
-    role: { type: String }
+    role: { type: String },
+    created: { type: Date, required: true },
+    modified: { type: Date, required: true }
 };
 
 // Create the schema

--- a/app/services/user-accounts-service.js
+++ b/app/services/user-accounts-service.js
@@ -171,7 +171,19 @@ exports.create = async function(data) {
     // Create the document
     const userAccount = new UserAccount(data);
 
+    // Create a unique id for this user
     userAccount.id = `user-account--${uuid.v4()}`;
+
+    // Add a timestamp recording when the user account was first created
+    // This should usually be undefined. It will only be defined when migrating user accounts from another system.
+    if (!userAccount.created) {
+        userAccount.created = new Date().toISOString();
+    }
+
+    // Add a timestamp recording when the user account was last modified
+    if (!userAccount.modified) {
+        userAccount.modified = userAccount.created;
+    }
 
     // Save the document in the database
     try {
@@ -215,8 +227,16 @@ exports.updateFull = function(userAccountId, data, callback) {
             return callback(null);
         }
         else {
-            // Copy data to found document and save
-            Object.assign(document, data);
+            // Copy data to found document
+            document.email = data.email;
+            document.username = data.username;
+            document.status = data.status;
+            document.role = data.role;
+
+            // Set the modified timestamp
+            document.modified = new Date().toISOString();
+
+            // And save
             document.save(function(err, savedDocument) {
                 if (err) {
                     if (err.name === 'MongoError' && err.code === 11000) {

--- a/app/tests/api/user-accounts/user-accounts.spec.js
+++ b/app/tests/api/user-accounts/user-accounts.spec.js
@@ -146,6 +146,11 @@ describe('User Accounts API', function () {
                     expect(userAccount.status).toBe(userAccount1.status);
                     expect(userAccount.role).toBe(userAccount1.role);
 
+                    // The created and modified timestamps should match
+                    expect(userAccount.created).toBeDefined();
+                    expect(userAccount.modified).toBeDefined();
+                    expect(userAccount.created).toEqual(userAccount.modified);
+
                     done();
                 }
             });
@@ -168,6 +173,12 @@ describe('User Accounts API', function () {
                     const userAccount = res.body;
                     expect(userAccount).toBeDefined();
                     expect(userAccount.identity).toBe(userAccount1.identity);
+
+                    // The modified timestamp should be different from the created timestamp
+                    expect(userAccount.created).toBeDefined();
+                    expect(userAccount.modified).toBeDefined();
+                    expect(userAccount.created).not.toEqual(userAccount.modified);
+
                     done();
                 }
             });


### PR DESCRIPTION
Add `created` and `modified` timestamps to the user account model and set them automatically in the user account service.

Closes #149 