### PR TITLE
add x_mitre_domains if it was empty

### DIFF
--- a/app/services/stix-bundles-service.js
+++ b/app/services/stix-bundles-service.js
@@ -127,6 +127,9 @@ exports.exportBundle = async function(options) {
     // Iterate over the relationships, keeping any that have a source_ref or target_ref that points at a primary object
     const relationships = [];
     for (const relationship of allRelationships) {
+	if(relationship.stix.x_mitre_domains.length === 0){
+	    relationship.stix.x_mitre_domains.push(options.domain)
+	}
         if (objectsMap.has(relationship.stix.source_ref) || objectsMap.has(relationship.stix.target_ref)) {
             relationships.push(relationship);
         }
@@ -145,6 +148,9 @@ exports.exportBundle = async function(options) {
         if (!objectsMap.has(relationship.stix.source_ref)) {
             const secondaryObject = await getAttackObject(relationship.stix.source_ref);
             if (secondaryObject) {
+		if(secondaryObject.stix.x_mitre_domains.length === 0){
+		    secondaryObject.stix.x_mitre_domains.push(options.domain)
+		}
                 secondaryObjects.push(secondaryObject);
                 objectsMap.set(secondaryObject.stix.id, true);
             }


### PR DESCRIPTION
Hi team, 

This change is aim to fix the issue #133 . When calling export api `/api/stix-bundles` the group object which is created by workbench will have empty `x_mitre_domains` field. That will make latest Navigator ignore the group. 

I'm trying to fill this field with the domain name input from url param domain, like `/api/stix-bundles/?domain=X`. Hope this will make sense.