### PR TITLE
Provide better debugging info when getting the Default Marking Definitions

### DIFF
--- a/app/api/definitions/paths/system-configuration-paths.yml
+++ b/app/api/definitions/paths/system-configuration-paths.yml
@@ -99,6 +99,14 @@ paths:
         This endpoint gets the default marking definition objects for the system.
       tags:
         - 'System Configuration'
+      parameters:
+        - name: refOnly
+          in: query
+          description: |
+            Only return the STIX ID of the default marking definitions instead of the objects.
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: 'An array of marking definition objects.'

--- a/app/controllers/system-configuration-controller.js
+++ b/app/controllers/system-configuration-controller.js
@@ -71,12 +71,13 @@ exports.retrieveAuthenticationConfig = function(req, res) {
 
 exports.retrieveDefaultMarkingDefinitions = async function(req, res) {
     try {
-        const defaultMarkingDefinitions = await systemConfigurationService.retrieveDefaultMarkingDefinitions();
-        logger.debug("Success: Retrieved default marking definitions.");
+        const options = { refOnly: req.query.refOnly };
+        const defaultMarkingDefinitions = await systemConfigurationService.retrieveDefaultMarkingDefinitions(options);
+        logger.debug('Success: Retrieved default marking definitions.');
         return res.status(200).send(defaultMarkingDefinitions);
     }
     catch(err) {
-        logger.error("Unable to retrieve default marking definitions, failed with error: " + err);
+        logger.error(`Unable to retrieve default marking definitions, failed with error: ${ err } (${ err.markingDefinitionRef })`);
         return res.status(500).send("Unable to retrieve default marking definitions. Server error.");
     }
 };
@@ -98,8 +99,8 @@ exports.setDefaultMarkingDefinitions = async function(req, res) {
         return res.status(204).send();
     }
     catch(err) {
-        logger.error("Unable to set default marking definitions, failed with error: " + err);
-        return res.status(500).send("Unable to default marking definitions. Server error.");
+        logger.error('Unable to set default marking definitions, failed with error: ' + err);
+        return res.status(500).send('Unable to default marking definitions. Server error.');
     }
 };
 

--- a/app/services/system-configuration-service.js
+++ b/app/services/system-configuration-service.js
@@ -138,7 +138,7 @@ exports.retrieveDefaultMarkingDefinitions = async function(options) {
                     if (markingDefinition) {
                         defaultMarkingDefinitions.push(markingDefinition);
                     } else {
-                        const error = new Error(errors.defaultMarkingDefinitionNotFound)
+                        const error = new Error(errors.defaultMarkingDefinitionNotFound);
                         error.markingDefinitionRef = stixId;
                         throw error;
                     }

--- a/app/tests/api/system-configuration/system-configuration.spec.js
+++ b/app/tests/api/system-configuration/system-configuration.spec.js
@@ -196,6 +196,21 @@ describe('System Configuration API', function () {
         expect(defaultMarkingDefinitions[0].stix.id).toBe(markingDefinition.stix.id);
     });
 
+    it('GET /api/config/default-marking-definitions returns an array containing the marking definition reference', async function () {
+        const res = await request(app)
+            .get('/api/config/default-marking-definitions?refOnly=true')
+            .set('Accept', 'application/json')
+            .expect(200)
+            .expect('Content-Type', /json/);
+
+        // We expect to get an empty array
+        const defaultMarkingDefinitions = res.body;
+        expect(defaultMarkingDefinitions).toBeDefined();
+        expect(Array.isArray(defaultMarkingDefinitions)).toBe(true)
+        expect(defaultMarkingDefinitions.length).toBe(1);
+        expect(defaultMarkingDefinitions[0]).toBe(markingDefinition.stix.id);
+    });
+
     it('GET /api/config/organization-namespace returns the default namespace', async function () {
         const res = await request(app)
             .get('/api/config/organization-namespace')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1454,9 +1454,9 @@
       }
     },
     "convict": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.0.tgz",
-      "integrity": "sha512-aCk1+VWt3TG6SJV59u+wwuza7lvtlJfj6zH/fmE1xzx5yZnNby1lPYkccq1mKaJJXHjk9cuVCFWVVIhbkpmwRw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.2.tgz",
+      "integrity": "sha512-3MsROJiEFN3BAzeFit1t87t7EUFzd44MNd13MLSikV2dsnDl7znwKgtYPPONtnDzxiDW0nBAsxVhSRNrjUrTTg==",
       "requires": {
         "lodash.clonedeep": "^4.5.0",
         "yargs-parser": "^20.2.7"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "async-await-retry": "^1.2.3",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",
-    "convict": "^6.2.0",
+    "convict": "^6.2.2",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-openapi-validator": "^4.13.1",


### PR DESCRIPTION
When the `GET /api/config/default-marking-definitions` endpoint is unable to retrieve the marking definition object, include the STIX ID of the missing object in the log.

Enable the `refOnly` query parameter for the same endpoint.

Add a test for the `refOnly` query parameter.

Closes #160 