### PR TITLE
Expand search to include the ATT&CK ID stored in the attack_id field

### DIFF
--- a/app/services/data-sources-service.js
+++ b/app/services/data-sources-service.js
@@ -50,7 +50,8 @@ exports.retrieveAll = function(options, callback) {
     if (typeof options.search !== 'undefined') {
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
-                    { 'stix.description': { '$regex': options.search, '$options': 'i' }}
+                    { 'stix.description': { '$regex': options.search, '$options': 'i' }},
+                    { 'workspace.attack_id': { '$regex': options.search, '$options': 'i' }}
                 ]}};
         aggregation.push(match);
     }

--- a/app/services/groups-service.js
+++ b/app/services/groups-service.js
@@ -49,9 +49,10 @@ exports.retrieveAll = function(options, callback) {
 
     if (typeof options.search !== 'undefined') {
         const match = { $match: { $or: [
-                        { 'stix.name': { '$regex': options.search, '$options': 'i' }},
-                        { 'stix.description': { '$regex': options.search, '$options': 'i' }}
-                        ]}};
+                    { 'stix.name': { '$regex': options.search, '$options': 'i' }},
+                    { 'stix.description': { '$regex': options.search, '$options': 'i' }},
+                    { 'workspace.attack_id': { '$regex': options.search, '$options': 'i' }}
+                ]}};
         aggregation.push(match);
     }
 

--- a/app/services/mitigations-service.js
+++ b/app/services/mitigations-service.js
@@ -49,7 +49,8 @@ exports.retrieveAll = function(options, callback) {
     if (typeof options.search !== 'undefined') {
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
-                    { 'stix.description': { '$regex': options.search, '$options': 'i' }}
+                    { 'stix.description': { '$regex': options.search, '$options': 'i' }},
+                    { 'workspace.attack_id': { '$regex': options.search, '$options': 'i' }}
                 ]}};
         aggregation.push(match);
     }

--- a/app/services/software-service.js
+++ b/app/services/software-service.js
@@ -51,7 +51,8 @@ exports.retrieveAll = function(options, callback) {
     if (typeof options.search !== 'undefined') {
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
-                    { 'stix.description': { '$regex': options.search, '$options': 'i' }}
+                    { 'stix.description': { '$regex': options.search, '$options': 'i' }},
+                    { 'workspace.attack_id': { '$regex': options.search, '$options': 'i' }}
                 ]}};
         aggregation.push(match);
     }

--- a/app/services/tactics-service.js
+++ b/app/services/tactics-service.js
@@ -49,7 +49,8 @@ exports.retrieveAll = function(options, callback) {
     if (typeof options.search !== 'undefined') {
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
-                    { 'stix.description': { '$regex': options.search, '$options': 'i' }}
+                    { 'stix.description': { '$regex': options.search, '$options': 'i' }},
+                    { 'workspace.attack_id': { '$regex': options.search, '$options': 'i' }}
                 ]}};
         aggregation.push(match);
     }

--- a/app/services/techniques-service.js
+++ b/app/services/techniques-service.js
@@ -49,7 +49,8 @@ exports.retrieveAll = function(options, callback) {
     if (typeof options.search !== 'undefined') {
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
-                    { 'stix.description': { '$regex': options.search, '$options': 'i' }}
+                    { 'stix.description': { '$regex': options.search, '$options': 'i' }},
+                    { 'workspace.attack_id': { '$regex': options.search, '$options': 'i' }}
                 ]}};
         aggregation.push(match);
     }

--- a/app/tests/api/groups/groups.query.json
+++ b/app/tests/api/groups/groups.query.json
@@ -8,9 +8,7 @@
     "spec_version": "2.1",
     "type": "intrusion-set",
     "description": "This is a group.",
-    "external_references": [
-      { "source_name": "source-1", "external_id": "s1" }
-    ],
+    "external_references": [],
     "object_marking_refs": [ "marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168" ],
     "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
     "x_mitre_version": "1.0"

--- a/app/tests/api/groups/groups.query.spec.js
+++ b/app/tests/api/groups/groups.query.spec.js
@@ -255,6 +255,10 @@ describe('Groups API Queries', function () {
                     expect(groups).toBeDefined();
                     expect(Array.isArray(groups)).toBe(true);
                     expect(groups.length).toBe(1);
+
+                    const group = groups[0];
+                    expect(group.workspace.workflow.state).toEqual('work-in-progress');
+
                     done();
                 }
             });
@@ -276,6 +280,10 @@ describe('Groups API Queries', function () {
                     expect(groups).toBeDefined();
                     expect(Array.isArray(groups)).toBe(true);
                     expect(groups.length).toBe(1);
+
+                    const group = groups[0];
+                    expect(group.workspace.attack_id).toEqual('G0001');
+
                     done();
                 }
             });

--- a/app/tests/api/techniques/techniques.spec.js
+++ b/app/tests/api/techniques/techniques.spec.js
@@ -406,6 +406,7 @@ describe('Techniques Basic API', function () {
                     expect(technique.stix).toBeDefined();
                     expect(technique.stix.id).toBe(technique2.stix.id);
                     expect(technique.stix.modified).toBe(technique2.stix.modified);
+                    
                     done();
                 }
             });
@@ -435,6 +436,8 @@ describe('Techniques Basic API', function () {
                     expect(technique.stix).toBeDefined();
                     expect(technique.stix.id).toBe(technique2.stix.id);
                     expect(technique.stix.modified).toBe(technique2.stix.modified);
+                    expect(technique.workspace.attack_id).toEqual('T9999');
+
                     done();
                 }
             });

--- a/app/tests/api/techniques/techniques.spec.js
+++ b/app/tests/api/techniques/techniques.spec.js
@@ -125,6 +125,7 @@ describe('Techniques Basic API', function () {
                     expect(technique1.stix.modified).toBeDefined();
                     expect(technique1.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
                     expect(technique1.workspace.workflow.created_by_user_account).toBeDefined();
+                    expect(technique1.workspace.attack_id).toBeDefined();
 
                     done();
                 }
@@ -201,6 +202,8 @@ describe('Techniques Basic API', function () {
                     expect(technique.stix.x_mitre_impact_type).toEqual(expect.arrayContaining(technique1.stix.x_mitre_impact_type));
                     expect(technique.stix.x_mitre_platforms).toEqual(expect.arrayContaining(technique1.stix.x_mitre_platforms));
                     expect(technique.stix.x_mitre_attack_spec_version).toBe(technique1.stix.x_mitre_attack_spec_version);
+
+                    expect(technique.workspace.attack_id).toEqual(technique1.workspace.attack_id);
 
                     expect(technique.stix.x_mitre_deprecated).not.toBeDefined();
                     expect(technique.stix.x_mitre_defense_bypassed).not.toBeDefined();
@@ -382,6 +385,35 @@ describe('Techniques Basic API', function () {
     it('GET /api/techniques uses the search parameter to return the latest version of the technique', function (done) {
         request(app)
             .get('/api/techniques?search=purple')
+            .set('Accept', 'application/json')
+            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get one technique in an array
+                    const techniques = res.body;
+                    expect(techniques).toBeDefined();
+                    expect(Array.isArray(techniques)).toBe(true);
+                    expect(techniques.length).toBe(1);
+
+                    // We expect it to be the latest version of the technique
+                    const technique = techniques[0];
+                    expect(technique).toBeDefined();
+                    expect(technique.stix).toBeDefined();
+                    expect(technique.stix.id).toBe(technique2.stix.id);
+                    expect(technique.stix.modified).toBe(technique2.stix.modified);
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/techniques uses the search parameter (ATT&CK ID) to return the latest version of the technique', function (done) {
+        request(app)
+            .get('/api/techniques?search=T9999')
             .set('Accept', 'application/json')
             .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
             .expect(200)


### PR DESCRIPTION
Adds the `workflow.attack_id` property when searching the techniques, tactics, software, mitigations, groups, and data sources endpoints.