### PR TITLE
Feature/#169 reserved chars

### DIFF
--- a/app/api/definitions/paths/attack-objects-paths.yml
+++ b/app/api/definitions/paths/attack-objects-paths.yml
@@ -67,6 +67,7 @@ paths:
             The search is case-insensitive.
           schema:
             type: string
+          allowReserved: true
           example: 'windows'
         - name: includePagination
           in: query

--- a/app/api/definitions/paths/collections-paths.yml
+++ b/app/api/definitions/paths/collections-paths.yml
@@ -71,6 +71,7 @@ paths:
             The search is case-insensitive.
           schema:
             type: string
+          allowReserved: true
           example: 'windows'
       responses:
         '200':

--- a/app/api/definitions/paths/data-components-paths.yml
+++ b/app/api/definitions/paths/data-components-paths.yml
@@ -59,6 +59,7 @@ paths:
             The search is case-insensitive.
           schema:
             type: string
+          allowReserved: true
           example: 'windows'
         - name: includePagination
           in: query

--- a/app/api/definitions/paths/data-sources-paths.yml
+++ b/app/api/definitions/paths/data-sources-paths.yml
@@ -59,6 +59,7 @@ paths:
             The search is case-insensitive.
           schema:
             type: string
+          allowReserved: true
           example: 'windows'
         - name: includePagination
           in: query

--- a/app/api/definitions/paths/groups-paths.yml
+++ b/app/api/definitions/paths/groups-paths.yml
@@ -59,6 +59,7 @@ paths:
             The search is case-insensitive.
           schema:
             type: string
+          allowReserved: true
           example: 'windows'
         - name: includePagination
           in: query

--- a/app/api/definitions/paths/matrices-paths.yml
+++ b/app/api/definitions/paths/matrices-paths.yml
@@ -60,6 +60,7 @@ paths:
             The search is case-insensitive.
           schema:
             type: string
+          allowReserved: true
           example: 'windows'
         - name: includePagination
           in: query

--- a/app/api/definitions/paths/mitigations-paths.yml
+++ b/app/api/definitions/paths/mitigations-paths.yml
@@ -59,6 +59,7 @@ paths:
             The search is case-insensitive.
           schema:
             type: string
+          allowReserved: true
           example: 'windows'
         - name: includePagination
           in: query

--- a/app/api/definitions/paths/notes-paths.yml
+++ b/app/api/definitions/paths/notes-paths.yml
@@ -58,6 +58,7 @@ paths:
             The search is case-insensitive.
           schema:
             type: string
+          allowReserved: true
           example: 'windows'
         - name: includePagination
           in: query

--- a/app/api/definitions/paths/references-paths.yml
+++ b/app/api/definitions/paths/references-paths.yml
@@ -38,6 +38,7 @@ paths:
             The search is case-insensitive.
           schema:
             type: string
+          allowReserved: true
           example: 'windows'
         - name: includePagination
           in: query

--- a/app/api/definitions/paths/software-paths.yml
+++ b/app/api/definitions/paths/software-paths.yml
@@ -59,6 +59,7 @@ paths:
             The search is case-insensitive.
           schema:
             type: string
+          allowReserved: true
           example: 'windows'
         - name: includePagination
           in: query

--- a/app/api/definitions/paths/tactics-paths.yml
+++ b/app/api/definitions/paths/tactics-paths.yml
@@ -59,6 +59,7 @@ paths:
             The search is case-insensitive.
           schema:
             type: string
+          allowReserved: true
           example: 'windows'
         - name: includePagination
           in: query

--- a/app/api/definitions/paths/techniques-paths.yml
+++ b/app/api/definitions/paths/techniques-paths.yml
@@ -60,6 +60,7 @@ paths:
             The search is case-insensitive.
           schema:
             type: string
+          allowReserved: true
           example: 'windows'
         - name: includePagination
           in: query

--- a/app/api/definitions/paths/user-accounts-paths.yml
+++ b/app/api/definitions/paths/user-accounts-paths.yml
@@ -57,6 +57,7 @@ paths:
             The search is case-insensitive.
           schema:
             type: string
+          allowReserved: true
           example: 'smith'
         - name: includePagination
           in: query

--- a/app/lib/regex.js
+++ b/app/lib/regex.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.sanitizeRegex = function(expression) {
+    // Compile the expression. If it's valid, return the expression. Otherwise, return an empty string.
+    try {
+        // eslint-disable-next-line no-new
+        new RegExp(expression);
+        return expression;
+    }
+    catch(err) {
+        return '';
+    }
+}

--- a/app/services/attack-objects-service.js
+++ b/app/services/attack-objects-service.js
@@ -3,6 +3,7 @@
 const AttackObject = require('../models/attack-object-model');
 const identitiesService = require('./identities-service');
 const systemConfigurationService = require('./system-configuration-service');
+const regexValidator = require('../lib/regex');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -47,6 +48,7 @@ exports.retrieveAll = async function(options) {
     aggregation.push({ $match: query });
 
     if (typeof options.search !== 'undefined') {
+        options.search = regexValidator.sanitizeRegex(options.search);
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
                     { 'stix.description': { '$regex': options.search, '$options': 'i' }}

--- a/app/services/collections-service.js
+++ b/app/services/collections-service.js
@@ -9,6 +9,7 @@ const systemConfigurationService = require('./system-configuration-service');
 const attackObjectsService = require('./attack-objects-service');
 const identitiesService = require('./identities-service');
 const config = require('../config/config');
+const regexValidator = require('../lib/regex');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -52,6 +53,7 @@ exports.retrieveAll = function(options, callback) {
     aggregation.push({ $match: query });
 
     if (typeof options.search !== 'undefined') {
+        options.search = regexValidator.sanitizeRegex(options.search);
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
                     { 'stix.description': { '$regex': options.search, '$options': 'i' }}

--- a/app/services/data-components-service.js
+++ b/app/services/data-components-service.js
@@ -6,6 +6,7 @@ const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
 const attackObjectsService = require('./attack-objects-service');
 const config = require('../config/config');
+const regexValidator = require('../lib/regex');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -47,6 +48,7 @@ exports.retrieveAll = function(options, callback) {
     ];
 
     if (typeof options.search !== 'undefined') {
+        options.search = regexValidator.sanitizeRegex(options.search);
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
                     { 'stix.description': { '$regex': options.search, '$options': 'i' }}

--- a/app/services/data-sources-service.js
+++ b/app/services/data-sources-service.js
@@ -7,6 +7,7 @@ const identitiesService = require('./identities-service');
 const dataComponentsService = require('./data-components-service');
 const attackObjectsService = require('./attack-objects-service');
 const config = require('../config/config');
+const regexValidator = require('../lib/regex');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -48,6 +49,7 @@ exports.retrieveAll = function(options, callback) {
     ];
 
     if (typeof options.search !== 'undefined') {
+        options.search = regexValidator.sanitizeRegex(options.search);
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
                     { 'stix.description': { '$regex': options.search, '$options': 'i' }},

--- a/app/services/groups-service.js
+++ b/app/services/groups-service.js
@@ -6,6 +6,7 @@ const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
 const attackObjectsService = require('./attack-objects-service');
 const config = require('../config/config');
+const regexValidator = require('../lib/regex');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -48,6 +49,7 @@ exports.retrieveAll = function(options, callback) {
     ];
 
     if (typeof options.search !== 'undefined') {
+        options.search = regexValidator.sanitizeRegex(options.search);
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
                     { 'stix.description': { '$regex': options.search, '$options': 'i' }},

--- a/app/services/matrices-service.js
+++ b/app/services/matrices-service.js
@@ -6,6 +6,7 @@ const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
 const attackObjectsService = require('./attack-objects-service');
 const config = require('../config/config');
+const regexValidator = require('../lib/regex');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -47,6 +48,7 @@ exports.retrieveAll = function(options, callback) {
     ];
 
     if (typeof options.search !== 'undefined') {
+        options.search = regexValidator.sanitizeRegex(options.search);
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
                     { 'stix.description': { '$regex': options.search, '$options': 'i' }}

--- a/app/services/mitigations-service.js
+++ b/app/services/mitigations-service.js
@@ -6,6 +6,7 @@ const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
 const attackObjectsService = require('./attack-objects-service');
 const config = require('../config/config');
+const regexValidator = require('../lib/regex');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -47,6 +48,7 @@ exports.retrieveAll = function(options, callback) {
     ];
 
     if (typeof options.search !== 'undefined') {
+        options.search = regexValidator.sanitizeRegex(options.search);
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
                     { 'stix.description': { '$regex': options.search, '$options': 'i' }},

--- a/app/services/notes-service.js
+++ b/app/services/notes-service.js
@@ -6,6 +6,7 @@ const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
 const attackObjectsService = require('./attack-objects-service');
 const config = require('../config/config');
+const regexValidator = require('../lib/regex');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -47,6 +48,7 @@ exports.retrieveAll = function(options, callback) {
     ];
 
     if (typeof options.search !== 'undefined') {
+        options.search = regexValidator.sanitizeRegex(options.search);
         const match = { $match: { $or: [
                     { 'stix.abstract': { '$regex': options.search, '$options': 'i' }},
                     { 'stix.content': { '$regex': options.search, '$options': 'i' }}

--- a/app/services/software-service.js
+++ b/app/services/software-service.js
@@ -6,6 +6,7 @@ const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
 const attackObjectsService = require('./attack-objects-service');
 const config = require('../config/config');
+const regexValidator = require('../lib/regex');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -49,6 +50,7 @@ exports.retrieveAll = function(options, callback) {
     ];
 
     if (typeof options.search !== 'undefined') {
+        options.search = regexValidator.sanitizeRegex(options.search);
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
                     { 'stix.description': { '$regex': options.search, '$options': 'i' }},

--- a/app/services/tactics-service.js
+++ b/app/services/tactics-service.js
@@ -6,6 +6,7 @@ const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
 const attackObjectsService = require('./attack-objects-service');
 const config = require('../config/config');
+const regexValidator = require('../lib/regex');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -47,6 +48,7 @@ exports.retrieveAll = function(options, callback) {
     ];
 
     if (typeof options.search !== 'undefined') {
+        options.search = regexValidator.sanitizeRegex(options.search);
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
                     { 'stix.description': { '$regex': options.search, '$options': 'i' }},

--- a/app/services/techniques-service.js
+++ b/app/services/techniques-service.js
@@ -6,6 +6,7 @@ const systemConfigurationService = require('./system-configuration-service');
 const identitiesService = require('./identities-service');
 const attackObjectsService = require('./attack-objects-service');
 const config = require('../config/config');
+const regexValidator = require('../lib/regex');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -47,6 +48,7 @@ exports.retrieveAll = function(options, callback) {
     ];
 
     if (typeof options.search !== 'undefined') {
+        options.search = regexValidator.sanitizeRegex(options.search);
         const match = { $match: { $or: [
                     { 'stix.name': { '$regex': options.search, '$options': 'i' }},
                     { 'stix.description': { '$regex': options.search, '$options': 'i' }},

--- a/app/services/user-accounts-service.js
+++ b/app/services/user-accounts-service.js
@@ -2,6 +2,7 @@
 
 const uuid = require('uuid');
 const UserAccount = require('../models/user-account-model');
+const regexValidator = require('../lib/regex');
 
 const errors = {
     missingParameter: 'Missing required parameter',
@@ -62,6 +63,7 @@ exports.retrieveAll = function(options, callback) {
     ];
 
     if (typeof options.search !== 'undefined') {
+        options.search = regexValidator.sanitizeRegex(options.search);
         const match = { $match: { $or: [
                     { 'username': { '$regex': options.search, '$options': 'i' }},
                     { 'email': { '$regex': options.search, '$options': 'i' }},


### PR DESCRIPTION
Modify OpenAPI schema to allow reserved characters in `search` query parameters. Also test `search` to see if it is a valid regex expression before using it in a database query.

Closes #169 