### PR TITLE
Feature/#177 export stix version

### DIFF
--- a/app/api/definitions/paths/stix-bundles-paths.yml
+++ b/app/api/definitions/paths/stix-bundles-paths.yml
@@ -44,10 +44,24 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: stixVersion
+          in: query
+          description: |
+            STIX version that the exported bundle should conform to.
+          schema:
+            type: string
+            default: '2.0'
         - name: includeMissingAttackId
           in: query
           description: |
             Whether to include objects that should have an ATT&CK ID set but do not.
+          schema:
+            type: boolean
+            default: false
+        - name: includeNotes
+          in: query
+          description: |
+            Whether to include notes in the bundle.
           schema:
             type: boolean
             default: false

--- a/app/controllers/stix-bundles-controller.js
+++ b/app/controllers/stix-bundles-controller.js
@@ -3,9 +3,15 @@
 const stixBundlesService = require('../services/stix-bundles-service');
 const logger = require('../lib/logger');
 
+const validStixVersions = [ '2.0', '2.1' ];
+
 exports.exportBundle = async function(req, res) {
     if (!req.query.domain) {
         return res.status(400).send('domain is required');
+    }
+
+    if (!validStixVersions.includes(req.query.stixVersion)) {
+        return res.status(400).send('invalid STIX version');
     }
 
     const options = {
@@ -13,7 +19,9 @@ exports.exportBundle = async function(req, res) {
         state: req.query.state,
         includeRevoked: req.query.includeRevoked,
         includeDeprecated: req.query.includeDeprecated,
-        includeMissingAttackId: req.query.includeMissingAttackId
+        stixVersion: req.query.stixVersion,
+        includeMissingAttackId: req.query.includeMissingAttackId,
+        includeNotes: req.query.includeNotes
     };
 
     try {

--- a/app/services/stix-bundles-service.js
+++ b/app/services/stix-bundles-service.js
@@ -58,9 +58,20 @@ function conformToStixVersion(stixObject, stixVersion) {
         if (stixObject.hasOwnProperty('spec_version')) {
             stixObject.spec_version = undefined;
         }
+
+        // STIX 2.0 malware may not have the property is_family
+        // eslint-disable-next-line no-prototype-builtins
+        if (stixObject.type === 'malware' && stixObject.hasOwnProperty('is_family')) {
+            stixObject.is_family = undefined;
+        }
     }
     else if (stixVersion === '2.1') {
         stixObject.spec_version = '2.1';
+
+        // STIX 2.1 malware must have the property is_family
+        if (stixObject.type === 'malware') {
+            stixObject.is_family = stixObject.is_family ?? true;
+        }
     }
 }
 

--- a/app/tests/api/stix-bundles/stix-bundles.spec.js
+++ b/app/tests/api/stix-bundles/stix-bundles.spec.js
@@ -534,7 +534,7 @@ describe('STIX Bundles Basic API', function () {
 
     it('GET /api/stix-bundles exports the STIX bundle for the enterprise domain', function (done) {
         request(app)
-            .get(`/api/stix-bundles?domain=${ enterpriseDomain }`)
+            .get(`/api/stix-bundles?domain=${ enterpriseDomain }&includeNotes=true`)
             .set('Accept', 'application/json')
             .expect(200)
             .expect('Content-Type', /json/)
@@ -558,7 +558,7 @@ describe('STIX Bundles Basic API', function () {
 
     it('GET /api/stix-bundles exports the STIX bundle for the enterprise domain including deprecated objects', function (done) {
         request(app)
-            .get(`/api/stix-bundles?domain=${ enterpriseDomain }&includeDeprecated=true`)
+            .get(`/api/stix-bundles?domain=${ enterpriseDomain }&includeDeprecated=true&includeNotes=true`)
             .set('Accept', 'application/json')
             .expect(200)
             .expect('Content-Type', /json/)


### PR DESCRIPTION
Modifies the STIX bundle export to allow the client to select the STIX version to be output.
Also fixes error which resulted in certain revoked secondary objects from being included in the bundle.
Makes notes optional when exporting STIX bundles.

Closes #177