### PR TITLE
Convert LinkById tags to Markdown Links when Exporting a Collection Bundle

### DIFF
--- a/app/config/config.js
+++ b/app/config/config.js
@@ -253,6 +253,10 @@ function loadConfig() {
                     }
                 }
             }
+        },
+        attackSourceNames: {
+            doc: 'Valid source_name values used in MITRE ATT&CK external_references',
+            default: ['mitre-attack', 'mitre-mobile-attack', 'mobile-attack', 'mitre-ics-attack']
         }
     });
 

--- a/app/lib/linkById.js
+++ b/app/lib/linkById.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const AttackObject = require('../models/attack-object-model');
+const config = require('../config/config');
 
 // Default implmentation. Retrieves the attack object from the database.
 async function getAttackObjectFromDatabase(attackId) {
@@ -14,10 +15,9 @@ async function getAttackObjectFromDatabase(attackId) {
 }
 exports.getAttackObjectFromDatabase = getAttackObjectFromDatabase;
 
-const sourceNames = ['mitre-attack', 'mitre-mobile-attack', 'mobile-attack', 'mitre-ics-attack'];
 function attackReference(externalReferences) {
     if (Array.isArray(externalReferences) && externalReferences.length > 0) {
-        return externalReferences.find(ref => sourceNames.includes(ref.source_name));
+        return externalReferences.find(ref => config.attackSourceNames.includes(ref.source_name));
     }
     else {
         return null;
@@ -91,3 +91,14 @@ async function convertLinkByIdTags (stixObject, getAttackObject) {
     }
 }
 exports.convertLinkByIdTags = convertLinkByIdTags;
+
+function getAttackId(stixObject) {
+    if (Array.isArray(stixObject?.external_references)) {
+        const mitreAttackReference = stixObject.external_references.find(externalReference => config.attackSourceNames.includes(externalReference.source_name));
+        return mitreAttackReference?.external_id;
+    }
+    else {
+        return null;
+    }
+}
+exports.getAttackId = getAttackId;

--- a/app/models/attack-object-model.js
+++ b/app/models/attack-object-model.js
@@ -4,6 +4,8 @@ const mongoose = require('mongoose');
 const workspaceDefinitions = require('./subschemas/workspace');
 const stixCoreDefinitions = require('./subschemas/stix-core');
 
+const config = require('../config/config');
+
 // Create the definition
 const attackObjectDefinition = {
     workspace: {
@@ -22,10 +24,9 @@ const options = {
 const attackObjectSchema = new mongoose.Schema(attackObjectDefinition, options);
 
 //Save the ATT&CK ID in a more easily queried location
-const sourceNames = ['mitre-attack', 'mitre-mobile-attack', 'mobile-attack', 'mitre-ics-attack'];
 attackObjectSchema.pre('save', function(next) {
     if (this.stix.external_references) {
-        const mitreAttackReference = this.stix.external_references.find(externalReference => sourceNames.includes(externalReference.source_name));
+        const mitreAttackReference = this.stix.external_references.find(externalReference => config.attackSourceNames.includes(externalReference.source_name));
         if (mitreAttackReference && mitreAttackReference.external_id) {
             this.workspace.attack_id = mitreAttackReference.external_id;
         }

--- a/app/services/stix-bundles-service.js
+++ b/app/services/stix-bundles-service.js
@@ -15,6 +15,7 @@ const Technique = require('../models/technique-model');
 
 const systemConfigurationService = require('./system-configuration-service');
 const linkById = require('../lib/linkById');
+const config = require("../config/config");
 
 const errors = {
     notFound: 'Domain not found',
@@ -37,12 +38,11 @@ function requiresAttackId(attackObject) {
     return attackIdObjectTypes.includes(attackObject?.stix.type);
 }
 
-const sourceNames = ['mitre-attack', 'mitre-mobile-attack', 'mobile-attack', 'mitre-ics-attack'];
 function hasAttackId(attackObject) {
     if (attackObject) {
         const externalReferences = attackObject?.stix?.external_references;
         if (Array.isArray(externalReferences) && externalReferences.length > 0) {
-            const mitreAttackReference = externalReferences.find(ref => sourceNames.includes(ref.source_name));
+            const mitreAttackReference = externalReferences.find(ref => config.attackSourceNames.includes(ref.source_name));
             if (mitreAttackReference?.external_id) {
                 return true;
             }


### PR DESCRIPTION
Also moves the list of ATT&CK `source_name` values to a shared location.