### PR TITLE
Remove empty arrays when exporting a STIX bundle.

### DIFF
--- a/app/services/stix-bundles-service.js
+++ b/app/services/stix-bundles-service.js
@@ -89,6 +89,20 @@ function conformToStixVersion(stixObject, stixVersion) {
             stixObject.is_family = stixObject.is_family ?? true;
         }
     }
+
+    // Remove empty arrays
+    if (Array.isArray(stixObject.x_mitre_contributors) && stixObject.x_mitre_contributors.length === 0) {
+        delete stixObject['x_mitre_contributors'];
+    }
+    if (Array.isArray(stixObject.x_mitre_platforms) && stixObject.x_mitre_platforms.length === 0) {
+        delete stixObject['x_mitre_platforms'];
+    }
+    if (Array.isArray(stixObject.x_mitre_aliases) && stixObject.x_mitre_aliases.length === 0) {
+        delete stixObject['x_mitre_aliases'];
+    }
+    if (Array.isArray(stixObject.x_mitre_domains) && stixObject.x_mitre_domains.length === 0) {
+        delete stixObject['x_mitre_domains'];
+    }
 }
 
 exports.exportBundle = async function(options) {

--- a/app/tests/import/collection-bundles-enterprise.spec.js
+++ b/app/tests/import/collection-bundles-enterprise.spec.js
@@ -9,6 +9,8 @@ const database = require('../../lib/database-in-memory');
 const databaseConfiguration = require('../../lib/database-configuration');
 const path = require("path");
 
+const login = require('../shared/login');
+
 const testFilePath = './test-files';
 
 // Get a list of collection bundle filenames in the test-files sub-directory
@@ -30,6 +32,7 @@ async function readJson(filePath) {
 
 describe('Collection Bundles API Full-Size Test', function() {
     let app;
+    let passportCookie;
 
     before(async function() {
         // Establish the database connection
@@ -41,6 +44,9 @@ describe('Collection Bundles API Full-Size Test', function() {
 
         // Initialize the express app
         app = await require('../../index').initializeApp();
+
+        // Log into the app
+        passportCookie = await login.loginAnonymous(app);
     });
 
     // Create one test suite for each collection bundle
@@ -60,6 +66,7 @@ describe('Collection Bundles API Full-Size Test', function() {
                     .post('/api/collection-bundles?checkOnly=true')
                     .send(body)
                     .set('Accept', 'application/json')
+                    .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
                     .expect(201)
                     .expect('Content-Type', /json/);
 
@@ -78,6 +85,7 @@ describe('Collection Bundles API Full-Size Test', function() {
                     .post('/api/collection-bundles?previewOnly=true')
                     .send(body)
                     .set('Accept', 'application/json')
+                    .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
                     .expect(201)
                     .expect('Content-Type', /json/);
 
@@ -96,6 +104,7 @@ describe('Collection Bundles API Full-Size Test', function() {
                     .post('/api/collection-bundles')
                     .send(body)
                     .set('Accept', 'application/json')
+                    .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
                     .expect(201)
                     .expect('Content-Type', /json/);
 
@@ -112,6 +121,7 @@ describe('Collection Bundles API Full-Size Test', function() {
                 const res = await request(app)
                     .get(`/api/stix-bundles?domain=${ domain }`)
                     .set('Accept', 'application/json')
+                    .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
                     .expect(200)
                     .expect('Content-Type', /json/);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1467,9 +1467,9 @@
       }
     },
     "convict": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.2.tgz",
-      "integrity": "sha512-3MsROJiEFN3BAzeFit1t87t7EUFzd44MNd13MLSikV2dsnDl7znwKgtYPPONtnDzxiDW0nBAsxVhSRNrjUrTTg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.3.tgz",
+      "integrity": "sha512-mTY04Qr7WrqiXifdeUYXr4/+Te4hPFWDvz6J2FVIKCLc2XBhq63VOSSYAKJ+unhZAYOAjmEdNswTOeHt7s++pQ==",
       "requires": {
         "lodash.clonedeep": "^4.5.0",
         "yargs-parser": "^20.2.7"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "async-await-retry": "^1.2.3",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",
-    "convict": "^6.2.2",
+    "convict": "^6.2.3",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-openapi-validator": "^4.13.7",


### PR DESCRIPTION
The STIX standard doesn't allow empty arrays. When exporting a STIX bundle, remove empty arrays for these properties:

- `x_mitre_contributors`
- `x_mitre_platforms`
- `x_mitre_aliases`
- `x_mitre_domains`