### PR TITLE
Bug/#197 duplicate reference

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -12,6 +12,7 @@ parserOptions:
 ignorePatterns:
   - node_modules/
   - app/api
+  - local-only/
 rules:
   accessor-pairs: error
   array-bracket-newline: 'off'

--- a/app/controllers/attack-objects-controller.js
+++ b/app/controllers/attack-objects-controller.js
@@ -15,18 +15,20 @@ exports.retrieveAll = async function(req, res) {
         includePagination: req.query.includePagination
     }
 
-    const results = await attackObjectsService.retrieveAll(options)
-        .catch (err => {
-            logger.error('Failed with error: ' + err);
-            return res.status(500).send('Unable to get ATT&CK objects. Server error.');
-        });
+    try {
+        const results = await attackObjectsService.retrieveAll(options);
 
-    if (options.includePagination) {
-        logger.debug(`Success: Retrieved ${results.data.length} of ${results.pagination.total} total ATT&CK object(s)`);
-    }
-    else {
-        logger.debug(`Success: Retrieved ${results.length} ATT&CK object(s)`);
-    }
+        if (options.includePagination) {
+            logger.debug(`Success: Retrieved ${results.data.length} of ${results.pagination.total} total ATT&CK object(s)`);
+        }
+        else {
+            logger.debug(`Success: Retrieved ${results.length} ATT&CK object(s)`);
+        }
 
-    return res.status(200).send(results);
+        return res.status(200).send(results);
+    }
+    catch (err) {
+        logger.error('Failed with error: ' + err);
+        return res.status(500).send('Unable to get ATT&CK objects. Server error.');
+    }
 };

--- a/app/controllers/references-controller.js
+++ b/app/controllers/references-controller.js
@@ -12,19 +12,20 @@ exports.retrieveAll = async function(req, res) {
         includePagination: req.query.includePagination
     }
 
-    const results = await referencesService.retrieveAll(options)
-        .catch(err => {
-            logger.error('Failed with error: ' + err);
-            return res.status(500).send('Unable to get references. Server error.');
-        });
-
-    if (options.includePagination) {
-        logger.debug(`Success: Retrieved ${ results.data.length } of ${ results.pagination.total } total reference(s)`);
+    try {
+        const results = await referencesService.retrieveAll(options);
+        if (options.includePagination) {
+            logger.debug(`Success: Retrieved ${ results.data.length } of ${ results.pagination.total } total reference(s)`);
+        }
+        else {
+            logger.debug(`Success: Retrieved ${ results.length } reference(s)`);
+        }
+        return res.status(200).send(results);
     }
-    else {
-        logger.debug(`Success: Retrieved ${ results.length } reference(s)`);
+    catch(err) {
+        logger.error('Failed with error: ' + err);
+        return res.status(500).send('Unable to get references. Server error.');
     }
-    return res.status(200).send(results);
 };
 
 exports.create = async function(req, res) {
@@ -37,19 +38,21 @@ exports.create = async function(req, res) {
     }
 
     // Create the reference
-    const reference = await referencesService.create(referenceData)
-        .catch(err => {
-            if (err.message === referencesService.errors.duplicateId) {
-                logger.warn("Duplicate source_name");
-                return res.status(409).send('Unable to create reference. Duplicate source_name.');
-            } else {
-                logger.error("***** Failed with error: " + err);
-                return res.status(500).send("Unable to create reference. Server error.");
-            }
-        });
-
-    logger.debug("Success: Created reference with source_name " + reference.source_name);
-    return res.status(201).send(reference);
+    try {
+        const reference = await referencesService.create(referenceData);
+        logger.debug("Success: Created reference with source_name " + reference.source_name);
+        return res.status(201).send(reference);
+    }
+    catch(err) {
+        if (err.message === referencesService.errors.duplicateId) {
+            logger.warn("Duplicate source_name");
+            return res.status(409).send('Unable to create reference. Duplicate source_name.');
+        }
+        else {
+            logger.error("***** Failed with error: " + err);
+            return res.status(500).send("Unable to create reference. Server error.");
+        }
+    }
 };
 
 exports.update = async function(req, res) {
@@ -57,16 +60,17 @@ exports.update = async function(req, res) {
     const referenceData = req.body;
 
     // Create the reference
-    const reference = await referencesService.update(referenceData)
-        .catch(err => {
-            logger.error('Failed with error: ' + err);
-            return res.status(500).send('Unable to update reference. Server error.');
-        });
-
-    if (!reference) {
-        return res.status(404).send('Reference not found.');
-    } else {
-        logger.debug('Success: Updated reference with source_name ' + reference.source_name);
-        return res.status(200).send(reference);
+        try {
+        const reference = await referencesService.update(referenceData);
+        if (!reference) {
+            return res.status(404).send('Reference not found.');
+        } else {
+            logger.debug('Success: Updated reference with source_name ' + reference.source_name);
+            return res.status(200).send(reference);
+        }
+    }
+    catch(err) {
+        logger.error('Failed with error: ' + err);
+        return res.status(500).send('Unable to update reference. Server error.');
     }
 };

--- a/app/services/attack-objects-service.js
+++ b/app/services/attack-objects-service.js
@@ -138,16 +138,18 @@ exports.retrieveVersionById = async function(stixId, modified) {
         attackObject = await retrieveRelationshipsVersionById(stixId, modified);
     }
     else {
-        attackObject = await AttackObject.findOne({ 'stix.id': stixId, 'stix.modified': modified })
-            .catch(err => {
-                if (err.name === 'CastError') {
-                    const error = new Error(errors.badlyFormattedParameter);
-                    error.parameterName = 'stixId';
-                    throw error;
-                } else {
-                    throw err;
-                }
-            });
+        try {
+            attackObject = await AttackObject.findOne({ 'stix.id': stixId, 'stix.modified': modified });
+        }
+        catch(err) {
+            if (err.name === 'CastError') {
+                const error = new Error(errors.badlyFormattedParameter);
+                error.parameterName = 'stixId';
+                throw error;
+            } else {
+                throw err;
+            }
+        }
     }
 
     // Note: attackObject is null if not found

--- a/app/tests/api/references/references.spec.js
+++ b/app/tests/api/references/references.spec.js
@@ -261,6 +261,42 @@ describe('References API', function () {
             });
     });
 
+    it('PUT /api/references does not update a reference when the source_name is missing', function (done) {
+        const body = { description: 'This reference does not have a source_name', url: '' };
+        request(app)
+            .put('/api/references')
+            .send(body)
+            .set('Accept', 'application/json')
+            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
+            .expect(400)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    done();
+                }
+            });
+    });
+
+    it('PUT /api/references does not update a reference when the source_name is not in the database', function (done) {
+        const body = {  source_name: 'not-a-reference', description: 'This reference is not in the database', url: '' };
+        request(app)
+            .put('/api/references')
+            .send(body)
+            .set('Accept', 'application/json')
+            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
+            .expect(404)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    done();
+                }
+            });
+    });
+
     it('PUT /api/references updates a reference', function (done) {
         reference1.description = 'This is a new description';
         const body = reference1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4610,9 +4610,9 @@
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
     "snyk": {
-      "version": "1.733.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.733.0.tgz",
-      "integrity": "sha512-Mi/wk9tw8ma4P2+2QwgzGDHcIG0Tfj0Wn7cliuUqd7CM8bg+Oryq3g4NcNK6mJZz0VaISF8MCIcIzbqV8v0JYg==",
+      "version": "1.947.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.947.0.tgz",
+      "integrity": "sha512-/u+HyhaIaFhnrpn+aOiGR0ts9ZR7mr6uiqgRn5EQIwaFKpCFOEnOJTlQAM25ggomqmxRldArMMXe4dBWw855LA==",
       "dev": true
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "parse5-query-domtree": "^1.0.2",
     "read-json-lines-sync": "^2.2.0",
     "set-cookie-parser": "^2.4.8",
-    "snyk": "^1.733.0",
+    "snyk": "^1.947.0",
     "superagent": "^6.1.0",
     "supertest": "^5.0.0"
   }


### PR DESCRIPTION
`.catch(err) => {}` was used in combination with `await` on calls to async functions. Changed to use conventional try-catch block around `await` call.

Also:
- Added additional tests for updating references
- Configured lint to ignore the `local-only` directory
- Bumped the version of snyk

Closes #197 