### PR TITLE
Add an endpoint that deletes a reference.

### DIFF
--- a/app/api/definitions/paths/references-paths.yml
+++ b/app/api/definitions/paths/references-paths.yml
@@ -57,7 +57,6 @@ paths:
                 type: array
                 items:
                   $ref: '../components/references.yml#/components/schemas/reference'
-
     post:
       summary: 'Create a reference'
       operationId: 'reference-create'
@@ -82,7 +81,6 @@ paths:
           description: 'Missing or invalid parameters were provided. The reference was not created.'
         '409':
           description: 'Duplicate `source_name`. The reference was not created.'
-
     put:
       summary: 'Update a reference'
       operationId: 'reference-update'
@@ -108,3 +106,24 @@ paths:
           description: 'Missing or invalid parameters were provided. The reference was not updated.'
         '404':
           description: 'A reference with the requested source_name was not found.'
+    delete:
+      summary: 'Delete a reference'
+      operationId: 'reference-delete-by-source-name'
+      description: |
+        This endpoint deletes a reference from the workspace.
+        The reference is identified by its source_name.
+        This endpoint does NOT check whether the reference is currently cited by an ATT&CK object.
+      tags:
+        - 'References'
+      parameters:
+        - name: sourceName
+          in: query
+          description: 'Source name of the reference to delete'
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 'The reference was successfully deleted.'
+        '404':
+          description: 'A reference with the requested source name was not found.'

--- a/app/controllers/references-controller.js
+++ b/app/controllers/references-controller.js
@@ -74,3 +74,20 @@ exports.update = async function(req, res) {
         return res.status(500).send('Unable to update reference. Server error.');
     }
 };
+
+exports.deleteBySourceName = async function(req, res) {
+    try {
+        const reference = await referencesService.deleteBySourceName(req.query.sourceName);
+        if (!reference) {
+            return res.status(404).send('Reference not found.');
+        }
+        else {
+            logger.debug(`Success: Deleted reference with source_name ${ reference.source_name}`);
+            return res.status(204).end();
+        }
+    }
+    catch(err) {
+        logger.error('Delete reference failed. ' + err);
+        return res.status(500).send('Unable to delete reference. Server error.');
+    }
+};

--- a/app/routes/references-routes.js
+++ b/app/routes/references-routes.js
@@ -23,6 +23,11 @@ router.route('/references')
         authn.authenticate,
         authz.requireRole(authz.editorOrHigher),
         referencesController.update
+    )
+    .delete(
+        authn.authenticate,
+        authz.requireRole(authz.editorOrHigher),
+        referencesController.deleteBySourceName
     );
 
 module.exports = router;

--- a/app/services/references-service.js
+++ b/app/services/references-service.js
@@ -129,3 +129,14 @@ exports.update = async function(data, callback) {
     }
 };
 
+exports.deleteBySourceName = async function (sourceName) {
+    if (!sourceName) {
+        const error = new Error(errors.missingParameter);
+        error.parameterName = 'sourceName';
+        throw error;
+    }
+
+    const deletedReference = await Reference.findOneAndRemove({ 'source_name': sourceName });
+    return deletedReference;
+};
+

--- a/app/tests/api/references/references.spec.js
+++ b/app/tests/api/references/references.spec.js
@@ -269,7 +269,7 @@ describe('References API', function () {
             .set('Accept', 'application/json')
             .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
             .expect(400)
-            .end(function(err, res) {
+            .end(function(err) {
                 if (err) {
                     done(err);
                 }
@@ -287,7 +287,7 @@ describe('References API', function () {
             .set('Accept', 'application/json')
             .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
             .expect(404)
-            .end(function(err, res) {
+            .end(function(err) {
                 if (err) {
                     done(err);
                 }
@@ -330,6 +330,54 @@ describe('References API', function () {
             .set('Accept', 'application/json')
             .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
             .expect(409)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    done();
+                }
+            });
+    });
+
+    it('DELETE /api/references does not delete a reference when the source_name is omitted', function (done) {
+        request(app)
+            .delete('/api/references')
+            .set('Accept', 'application/json')
+            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
+            .expect(400)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    done();
+                }
+            });
+    });
+
+    it('DELETE /api/references does not delete a reference with a non-existent source_name', function (done) {
+        request(app)
+            .delete('/api/references?sourceName=not-a-reference')
+            .set('Accept', 'application/json')
+            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
+            .expect(404)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    done();
+                }
+            });
+    });
+
+    it('DELETE /api/references deletes a reference', function (done) {
+        request(app)
+            .delete(`/api/references?sourceName=${ reference1.source_name }`)
+            .set('Accept', 'application/json')
+            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
+            .expect(204)
             .end(function(err, res) {
                 if (err) {
                     done(err);


### PR DESCRIPTION
Adds the endpoint:

```
DELETE /api/references?sourceName=mySourceName
```

which deletes the reference with the provided `sourceName`.

Note that this endpoint does not check for ATT&CK objects that might cite the reference or ATT&CK objects that have been published. Those can be added in later if necessary.

Closes #199 