### PR TITLE
Add Containers to allowed Platforms; Migrate to Mongoose 6

### DIFF
--- a/app/config/allowed-values.json
+++ b/app/config/allowed-values.json
@@ -17,7 +17,8 @@
               "Azure AD",
               "SaaS",
               "IaaS",
-              "Google Workspace"
+              "Google Workspace",
+              "Containers"
             ]
           },
           {
@@ -163,7 +164,8 @@
               "Azure",
               "Office 365",
               "Azure AD",
-              "SaaS"
+              "SaaS",
+              "Containers"
             ]
           },
           {

--- a/app/lib/database-connection.js
+++ b/app/lib/database-connection.js
@@ -23,7 +23,7 @@ exports.initializeConnection = async function(options) {
 
     // Bootstrap db connection
     logger.info('Mongoose attempting to connect to ' + databaseUrl);
-    await mongoose.connect(databaseUrl, { useNewUrlParser: true, useUnifiedTopology: true });
+    await mongoose.connect(databaseUrl);
 
     logger.info('Mongoose connected to ' + databaseUrl);
 }

--- a/app/lib/database-in-memory.js
+++ b/app/lib/database-in-memory.js
@@ -10,16 +10,10 @@ exports.initializeConnection = async function() {
     // Configure mongoose to use ES6 promises
     mongoose.Promise = global.Promise;
 
-    // Tell mongoose to use the native mongoDB findOneAndUpdate() function
-    mongoose.set('useFindAndModify', false);
-
-    // Tell mongoose to use createIndex() instead of ensureIndex()
-    mongoose.set('useCreateIndex', true);
-
     // Bootstrap db connection
     logger.info('Mongoose attempting to connect to in memory database at ' + uri);
     try {
-        await mongoose.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true });
+        await mongoose.connect(uri);
     } catch (error) {
         handleError(error);
     }

--- a/app/services/collection-bundles-service.js
+++ b/app/services/collection-bundles-service.js
@@ -616,7 +616,7 @@ exports.importBundle = function(collection, data, options, callback) {
                                 return callback4(null, result.savedCollection);
                             })
                             .catch(function (err) {
-                                if (err.name === 'MongoError' && err.code === 11000) {
+                                if (err.name === 'MongoServerError' && err.code === 11000) {
                                     // 11000 = Duplicate index
                                     const error = new Error(errors.duplicateCollection);
                                     return callback4(error);

--- a/app/services/collection-indexes-service.js
+++ b/app/services/collection-indexes-service.js
@@ -63,7 +63,7 @@ exports.create = function(data, callback) {
     // Save the document in the database
     collectionIndex.save(function(err, collectionIndex) {
         if (err) {
-            if (err.name === 'MongoError' && err.code === 11000) {
+            if (err.name === 'MongoServerError' && err.code === 11000) {
                 // 11000 = Duplicate index
                 const error = new Error(errors.duplicateId);
                 return callback(error);
@@ -105,7 +105,7 @@ exports.updateFull = function(id, data, callback) {
             Object.assign(collectionIndex, data);
             collectionIndex.save(function(err, savedCollectionIndex) {
                 if (err) {
-                    if (err.name === 'MongoError' && err.code === 11000) {
+                    if (err.name === 'MongoServerError' && err.code === 11000) {
                         // 11000 = Duplicate index
                         var error = new Error(errors.duplicateId);
                         return callback(error);

--- a/app/services/collections-service.js
+++ b/app/services/collections-service.js
@@ -323,7 +323,7 @@ exports.create = async function(data, options) {
         return { savedCollection, insertionErrors };
     }
     catch (err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             const error = new Error(errors.duplicateId);
             throw error;

--- a/app/services/data-components-service.js
+++ b/app/services/data-components-service.js
@@ -342,7 +342,7 @@ exports.create = async function(data, options) {
         return savedDataComponent;
     }
     catch (err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             const error = new Error(errors.duplicateId);
             throw error;
@@ -386,7 +386,7 @@ exports.updateFull = function(stixId, stixModified, data, callback) {
             Object.assign(document, data);
             document.save(function(err, savedDocument) {
                 if (err) {
-                    if (err.name === 'MongoError' && err.code === 11000) {
+                    if (err.name === 'MongoServerError' && err.code === 11000) {
                         // 11000 = Duplicate index
                         var error = new Error(errors.duplicateId);
                         return callback(error);

--- a/app/services/data-sources-service.js
+++ b/app/services/data-sources-service.js
@@ -289,7 +289,7 @@ exports.create = async function(data, options) {
         return savedDataSource;
     }
     catch (err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             const error = new Error(errors.duplicateId);
             throw error;
@@ -333,7 +333,7 @@ exports.updateFull = function(stixId, stixModified, data, callback) {
             Object.assign(document, data);
             document.save(function(err, savedDocument) {
                 if (err) {
-                    if (err.name === 'MongoError' && err.code === 11000) {
+                    if (err.name === 'MongoServerError' && err.code === 11000) {
                         // 11000 = Duplicate index
                         var error = new Error(errors.duplicateId);
                         return callback(error);

--- a/app/services/groups-service.js
+++ b/app/services/groups-service.js
@@ -267,7 +267,7 @@ exports.create = async function(data, options) {
         return savedGroup;
     }
     catch (err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             const error = new Error(errors.duplicateId);
             throw error;
@@ -311,7 +311,7 @@ exports.updateFull = function(stixId, stixModified, data, callback) {
             Object.assign(document, data);
             document.save(function(err, savedDocument) {
                 if (err) {
-                    if (err.name === 'MongoError' && err.code === 11000) {
+                    if (err.name === 'MongoServerError' && err.code === 11000) {
                         // 11000 = Duplicate index
                         var error = new Error(errors.duplicateId);
                         return callback(error);

--- a/app/services/identities-service.js
+++ b/app/services/identities-service.js
@@ -226,7 +226,7 @@ exports.create = async function(data, options) {
         return savedIdentity;
     }
     catch (err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             const error = new Error(errors.duplicateId);
             throw error;
@@ -270,7 +270,7 @@ exports.updateFull = function(stixId, stixModified, data, callback) {
             Object.assign(document, data);
             document.save(function(err, savedDocument) {
                 if (err) {
-                    if (err.name === 'MongoError' && err.code === 11000) {
+                    if (err.name === 'MongoServerError' && err.code === 11000) {
                         // 11000 = Duplicate index
                         var error = new Error(errors.duplicateId);
                         return callback(error);

--- a/app/services/marking-definitions-service.js
+++ b/app/services/marking-definitions-service.js
@@ -173,7 +173,7 @@ exports.create = async function(data, options) {
         return savedMarkingDefinition;
     }
     catch(err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             const error = new Error(errors.duplicateId);
             throw error;
@@ -215,7 +215,7 @@ exports.updateFull = function(stixId, data, callback) {
             Object.assign(document, data);
             document.save(function(err, savedDocument) {
                 if (err) {
-                    if (err.name === 'MongoError' && err.code === 11000) {
+                    if (err.name === 'MongoServerError' && err.code === 11000) {
                         // 11000 = Duplicate index
                         const error = new Error(errors.duplicateId);
                         return callback(error);

--- a/app/services/matrices-service.js
+++ b/app/services/matrices-service.js
@@ -264,7 +264,7 @@ exports.create = async function(data, options) {
         return savedMatrix;
     }
     catch (err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             const error = new Error(errors.duplicateId);
             throw error;
@@ -308,7 +308,7 @@ exports.updateFull = function(stixId, stixModified, data, callback) {
             Object.assign(document, data);
             document.save(function(err, savedDocument) {
                 if (err) {
-                    if (err.name === 'MongoError' && err.code === 11000) {
+                    if (err.name === 'MongoServerError' && err.code === 11000) {
                         // 11000 = Duplicate index
                         var error = new Error(errors.duplicateId);
                         return callback(error);

--- a/app/services/mitigations-service.js
+++ b/app/services/mitigations-service.js
@@ -263,7 +263,7 @@ exports.create = async function(data, options) {
         return savedMitigation;
     }
     catch(err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             const error = new Error(errors.duplicateId);
             throw error;
@@ -307,7 +307,7 @@ exports.updateFull = function(stixId, stixModified, data, callback) {
             Object.assign(document, data);
             document.save(function(err, savedDocument) {
                 if (err) {
-                    if (err.name === 'MongoError' && err.code === 11000) {
+                    if (err.name === 'MongoServerError' && err.code === 11000) {
                         // 11000 = Duplicate index
                         var error = new Error(errors.duplicateId);
                         return callback(error);

--- a/app/services/notes-service.js
+++ b/app/services/notes-service.js
@@ -261,7 +261,7 @@ exports.create = async function(data, options) {
         return savedNote;
     }
     catch(err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             const error = new Error(errors.duplicateId);
             throw error;
@@ -305,7 +305,7 @@ exports.updateVersion = function(stixId, stixModified, data, callback) {
             Object.assign(document, data);
             document.save(function(err, savedDocument) {
                 if (err) {
-                    if (err.name === 'MongoError' && err.code === 11000) {
+                    if (err.name === 'MongoServerError' && err.code === 11000) {
                         // 11000 = Duplicate index
                         var error = new Error(errors.duplicateId);
                         return callback(error);

--- a/app/services/references-service.js
+++ b/app/services/references-service.js
@@ -83,7 +83,7 @@ exports.create = async function(data) {
         return savedReference;
     }
     catch(err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             throw new Error(errors.duplicateId);
         } else {
@@ -120,7 +120,7 @@ exports.update = async function(data, callback) {
             error.parameterName = 'source_name';
             return callback(error);
         }
-        else  if (err.name === 'MongoError' && err.code === 11000) {
+        else  if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             throw new Error(errors.duplicateId);
         } else {

--- a/app/services/relationships-service.js
+++ b/app/services/relationships-service.js
@@ -333,7 +333,7 @@ exports.create = async function(data, options) {
         return savedRelationshipe;
     }
     catch (err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             const error = new Error(errors.duplicateId);
             throw error;
@@ -377,7 +377,7 @@ exports.updateFull = function(stixId, stixModified, data, callback) {
             Object.assign(document, data);
             document.save(function(err, savedDocument) {
                 if (err) {
-                    if (err.name === 'MongoError' && err.code === 11000) {
+                    if (err.name === 'MongoServerError' && err.code === 11000) {
                         // 11000 = Duplicate index
                         var error = new Error(errors.duplicateId);
                         return callback(error);

--- a/app/services/software-service.js
+++ b/app/services/software-service.js
@@ -279,7 +279,7 @@ exports.create = async function(data, options) {
         return savedSoftware;
     }
     catch(err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             const error = new Error(errors.duplicateId);
             throw error;
@@ -323,7 +323,7 @@ exports.updateFull = function(stixId, stixModified, data, callback) {
             Object.assign(document, data);
             document.save(function(err, savedDocument) {
                 if (err) {
-                    if (err.name === 'MongoError' && err.code === 11000) {
+                    if (err.name === 'MongoServerError' && err.code === 11000) {
                         // 11000 = Duplicate index
                         var error = new Error(errors.duplicateId);
                         return callback(error);

--- a/app/services/tactics-service.js
+++ b/app/services/tactics-service.js
@@ -262,7 +262,7 @@ exports.create = async function(data, options) {
         return savedTactic;
     }
     catch(err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             const error = new Error(errors.duplicateId);
             throw error;
@@ -306,7 +306,7 @@ exports.updateFull = function(stixId, stixModified, data, callback) {
             Object.assign(document, data);
             document.save(function(err, savedDocument) {
                 if (err) {
-                    if (err.name === 'MongoError' && err.code === 11000) {
+                    if (err.name === 'MongoServerError' && err.code === 11000) {
                         // 11000 = Duplicate index
                         var error = new Error(errors.duplicateId);
                         return callback(error);

--- a/app/services/techniques-service.js
+++ b/app/services/techniques-service.js
@@ -265,7 +265,7 @@ exports.create = async function(data, options) {
         return savedTechnique;
     }
     catch (err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             const error = new Error(errors.duplicateId);
             throw error;
@@ -309,7 +309,7 @@ exports.updateFull = function(stixId, stixModified, data, callback) {
             Object.assign(document, data);
             document.save(function(err, savedDocument) {
                 if (err) {
-                    if (err.name === 'MongoError' && err.code === 11000) {
+                    if (err.name === 'MongoServerError' && err.code === 11000) {
                         // 11000 = Duplicate index
                         var error = new Error(errors.duplicateId);
                         return callback(error);

--- a/app/services/user-accounts-service.js
+++ b/app/services/user-accounts-service.js
@@ -219,7 +219,7 @@ exports.create = async function(data) {
         return savedUserAccount;
     }
     catch (err) {
-        if (err.name === 'MongoError' && err.code === 11000) {
+        if (err.name === 'MongoServerError' && err.code === 11000) {
             // 11000 = Duplicate index
             const error = new Error(errors.duplicateId);
             throw error;
@@ -266,7 +266,7 @@ exports.updateFull = function(userAccountId, data, callback) {
             // And save
             document.save(function(err, savedDocument) {
                 if (err) {
-                    if (err.name === 'MongoError' && err.code === 11000) {
+                    if (err.name === 'MongoServerError' && err.code === 11000) {
                         // 11000 = Duplicate index
                         var error = new Error(errors.duplicateId);
                         return callback(error);

--- a/app/tests/api/groups/groups.spec.js
+++ b/app/tests/api/groups/groups.spec.js
@@ -287,7 +287,7 @@ describe('Groups API', function () {
     let group2;
     it('POST /api/groups should create a new version of a group with a duplicate stix.id but different stix.modified date', async function () {
         // Add another default marking definition
-        markingDefinitionData.stix.definition = 'This is the second default marking definition';
+        markingDefinitionData.stix.definition.statement = 'This is the second default marking definition';
         defaultMarkingDefinition2 = await addDefaultMarkingDefinition(markingDefinitionData);
 
         group2 = _.cloneDeep(group1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -624,14 +624,6 @@
         "@types/node": "*"
       }
     },
-    "@types/bson": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
-      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -712,15 +704,6 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
-    "@types/mongodb": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
-      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "requires": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/multer": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.7.tgz",
@@ -764,6 +747,20 @@
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz",
       "integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==",
       "dev": true
+    },
+    "@types/webidl-conversions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
     },
     "@types/yargs": {
       "version": "15.0.12",
@@ -954,8 +951,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -975,15 +971,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
       "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
       }
-    },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -1042,13 +1035,14 @@
     "bson": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+      "dev": true,
+      "optional": true
     },
     "buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -1478,7 +1472,9 @@
     "denque": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
-      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==",
+      "dev": true,
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -2409,8 +2405,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -2462,6 +2457,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "ipaddr.js": {
       "version": "1.9.0",
@@ -2885,9 +2885,9 @@
       "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "kareem": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
-      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.4.1.tgz",
+      "integrity": "sha512-aJ9opVoXroQUPfovYP5kaj2lM7Jn02Gw13bL0lg9v0V7SaUc0qavPs0Eue7d2DcC3NjqI6QAUElXNsuZSeM+EA=="
     },
     "kuler": {
       "version": "2.0.0",
@@ -3350,6 +3350,39 @@
         "saslprep": "^1.0.0"
       }
     },
+    "mongodb-connection-string-url": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
+      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+        },
+        "whatwg-url": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
+      }
+    },
     "mongodb-memory-server": {
       "version": "6.9.6",
       "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-6.9.6.tgz",
@@ -3423,55 +3456,50 @@
       }
     },
     "mongoose": {
-      "version": "5.13.10",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.10.tgz",
-      "integrity": "sha512-h1tkPu/3grQjdWjoIA3uUNWvDFDcaNGwcmBLEkK9t/kzKq4L4fB2EoA/VLjQ7WGTL/pDKH6OElBTK7x/QPRvbg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.5.1.tgz",
+      "integrity": "sha512-8C0213y279nrSp6Au+WB+l/VczcotMU65jalTJJxU6KYf/Kd8gNW9+B3giWNJOVd8VvKvUQG0suWv/Vngp/83A==",
       "requires": {
-        "@types/bson": "1.x || 4.0.x",
-        "@types/mongodb": "^3.5.27",
-        "bson": "^1.1.4",
-        "kareem": "2.3.2",
-        "mongodb": "3.6.11",
-        "mongoose-legacy-pluralize": "1.0.2",
-        "mpath": "0.8.4",
-        "mquery": "3.2.5",
-        "ms": "2.1.2",
-        "optional-require": "1.0.x",
-        "regexp-clone": "1.0.0",
-        "safe-buffer": "5.2.1",
-        "sift": "13.5.2",
-        "sliced": "1.0.1"
+        "bson": "^4.6.5",
+        "kareem": "2.4.1",
+        "mongodb": "4.8.1",
+        "mpath": "0.9.0",
+        "mquery": "4.0.3",
+        "ms": "2.1.3",
+        "sift": "16.0.0"
       },
       "dependencies": {
-        "mongodb": {
-          "version": "3.6.11",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
-          "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
+        "bson": {
+          "version": "4.6.5",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
+          "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
           "requires": {
-            "bl": "^2.2.1",
-            "bson": "^1.1.4",
-            "denque": "^1.4.1",
-            "optional-require": "^1.0.3",
-            "safe-buffer": "^5.1.2",
-            "saslprep": "^1.0.0"
+            "buffer": "^5.6.0"
+          }
+        },
+        "denque": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+          "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
+        },
+        "mongodb": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.8.1.tgz",
+          "integrity": "sha512-/NyiM3Ox9AwP5zrfT9TXjRKDJbXlLaUDQ9Rg//2lbg8D2A8GXV0VidYYnA/gfdK6uwbnL4FnAflH7FbGw3TS7w==",
+          "requires": {
+            "bson": "^4.6.5",
+            "denque": "^2.0.1",
+            "mongodb-connection-string-url": "^2.5.2",
+            "saslprep": "^1.0.3",
+            "socks": "^2.6.2"
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
-    },
-    "mongoose-legacy-pluralize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
     "morgan": {
       "version": "1.10.0",
@@ -3493,29 +3521,30 @@
       }
     },
     "mpath": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
-      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew=="
     },
     "mquery": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
-      "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
+      "integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
       "requires": {
-        "bluebird": "3.5.1",
-        "debug": "3.1.0",
-        "regexp-clone": "^1.0.0",
-        "safe-buffer": "5.1.2",
-        "sliced": "1.0.1"
+        "debug": "4.x"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.2"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -3812,7 +3841,9 @@
     "optional-require": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
+      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==",
+      "dev": true,
+      "optional": true
     },
     "optionator": {
       "version": "0.9.1",
@@ -4138,11 +4169,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "regexp-clone": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
-      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
-    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -4298,9 +4324,9 @@
       "dev": true
     },
     "sift": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.0.tgz",
+      "integrity": "sha512-ILTjdP2Mv9V1kIxWMXeMTIRbOBrqKc4JAXmFMnFq3fKeyQ2Qwa3Dw1ubcye3vR+Y6ofA0b9gNDr/y2t6eUeIzQ=="
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -4359,16 +4385,25 @@
         }
       }
     },
-    "sliced": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
     "snyk": {
       "version": "1.947.0",
       "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.947.0.tgz",
       "integrity": "sha512-/u+HyhaIaFhnrpn+aOiGR0ts9ZR7mr6uiqgRn5EQIwaFKpCFOEnOJTlQAM25ggomqmxRldArMMXe4dBWw855LA==",
       "dev": true
+    },
+    "socks": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
+      "integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
+      "requires": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      }
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jwks-rsa": "^2.0.5",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
-    "mongoose": "^5.13.10",
+    "mongoose": "^6.5.1",
     "morgan": "^1.10.0",
     "nanoid": "^3.3.0",
     "node-cache": "^5.1.2",


### PR DESCRIPTION
Add `Containers` to the list of allowed values for Enterprise techniques and software.

Migrate to Mongoose 6 (fixes snyk error).

Closes #211 