### PR TITLE
Add the option to return all versions of objects to the GET /api/attack-objects endpoint

### DIFF
--- a/app/api/definitions/paths/attack-objects-paths.yml
+++ b/app/api/definitions/paths/attack-objects-paths.yml
@@ -77,6 +77,17 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: versions
+          in: query
+          description: |
+            The versions of the ATT&CK objects to retrieve.
+            `all` gets all versions of the objects, `latest` gets only the latest version.
+          schema:
+            type: string
+            enum:
+              - all
+              - latest
+            default: latest
       responses:
         '200':
           description: 'A list of ATT&CK Objects.'

--- a/app/controllers/attack-objects-controller.js
+++ b/app/controllers/attack-objects-controller.js
@@ -12,7 +12,8 @@ exports.retrieveAll = async function(req, res) {
         includeRevoked: req.query.includeRevoked,
         includeDeprecated: req.query.includeDeprecated,
         search: req.query.search,
-        includePagination: req.query.includePagination
+        includePagination: req.query.includePagination,
+        versions: req.query.versions
     }
 
     try {

--- a/app/tests/api/attack-objects/attack-objects-1.json
+++ b/app/tests/api/attack-objects/attack-objects-1.json
@@ -63,6 +63,22 @@
           "object_modified": "2022-09-09T01:02:03.000Z"
         },
         {
+          "object_ref": "malware--9c5ab575-f015-462c-92a0-f887277d8519",
+          "object_modified": "2022-06-01T00:00:00.000Z"
+        },
+        {
+          "object_ref": "intrusion-set--925216d2-dd4c-4487-8d19-f96e81dabd5d",
+          "object_modified": "2022-06-01T00:00:00.000Z"
+        },
+        {
+          "object_ref": "course-of-action--d77711b8-a970-47a0-b819-03d088d778c4",
+          "object_modified": "2022-06-01T00:00:00.000Z"
+        },
+        {
+          "object_ref": "relationship--1c4c5ab3-ae2b-4f67-9802-d7f18d9f0d37",
+          "object_modified": "2022-06-01T00:00:00.000Z"
+        },
+        {
           "object_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
           "object_modified": "2017-06-01T00:00:00.000Z"
         },
@@ -425,6 +441,79 @@
       "x_mitre_modified_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
       "x_mitre_version": "1.0",
       "spec_version": "2.1"
+    },
+    {
+      "id": "malware--9c5ab575-f015-462c-92a0-f887277d8519",
+      "name": "software-1",
+      "spec_version": "2.1",
+      "type": "malware",
+      "description": "This is a malware type of software.",
+      "is_family": false,
+      "external_references": [
+        { "source_name": "mitre-attack", "external_id": "SX3333", "url": "https://attack.mitre.org/software/SX3333" },
+        { "source_name": "source-1", "external_id": "s1" }
+      ],
+      "object_marking_refs": [ "marking-definition--c2a0b8f8-51d4-4702-8e42-ce7a65235bce" ],
+      "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+      "x_mitre_version": "1.1",
+      "x_mitre_aliases": [
+        "software-1"
+      ],
+      "x_mitre_platforms": [
+        "platform-1"
+      ],
+      "x_mitre_contributors": [
+        "contributor-1",
+        "contributor-2"
+      ],
+      "x_mitre_domains": [
+        "mobile-attack"
+      ],
+      "created": "2022-06-01T00:00:00.000Z",
+      "modified": "2022-06-01T00:00:00.000Z"
+    },
+    {
+      "id": "intrusion-set--925216d2-dd4c-4487-8d19-f96e81dabd5d",
+      "name": "intrusion-set-1",
+      "spec_version": "2.1",
+      "type": "intrusion-set",
+      "description": "This is a group.",
+      "external_references": [
+        { "source_name": "mitre-attack", "external_id": "GX1111", "url": "https://attack.mitre.org/groups/GX1111" },
+        { "source_name": "source-1", "external_id": "s1" }
+      ],
+      "object_marking_refs": [ "marking-definition--c2a0b8f8-51d4-4702-8e42-ce7a65235bce" ],
+      "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+      "created": "2022-06-01T00:00:00.000Z",
+      "modified": "2022-06-01T00:00:00.000Z"
+    },
+    {
+      "id": "course-of-action--d77711b8-a970-47a0-b819-03d088d778c4",
+      "name": "course-of-action-1",
+      "spec_version": "2.1",
+      "type": "course-of-action",
+      "description": "This is a mitigation.",
+      "external_references": [
+        { "source_name": "mitre-attack", "external_id": "T9999", "url": "https://attack.mitre.org/mitigations/T9999" },
+        { "source_name": "source-1", "external_id": "s1" }
+      ],
+      "object_marking_refs": [ "marking-definition--c2a0b8f8-51d4-4702-8e42-ce7a65235bce" ],
+      "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+      "x_mitre_version": "1.1",
+      "created": "2022-06-01T00:00:00.000Z",
+      "modified": "2022-06-01T00:00:00.000Z"
+    },
+    {
+      "id": "relationship--1c4c5ab3-ae2b-4f67-9802-d7f18d9f0d37",
+      "spec_version": "2.1",
+      "type": "relationship",
+      "relationship_type": "uses",
+      "source_ref": "intrusion-set--925216d2-dd4c-4487-8d19-f96e81dabd5d",
+      "target_ref": "attack-pattern--757471d4-d931-4109-82dd-cdd50c04744e",
+      "object_marking_refs": [ "marking-definition--c2a0b8f8-51d4-4702-8e42-ce7a65235bce" ],
+      "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+      "created": "2022-06-01T00:00:00.000Z",
+      "modified": "2022-06-01T00:00:00.000Z"
     },
     {
       "object_marking_refs": [

--- a/app/tests/api/attack-objects/attack-objects-2.json
+++ b/app/tests/api/attack-objects/attack-objects-2.json
@@ -1,0 +1,105 @@
+{
+  "type": "bundle",
+  "id": "bundle--935171d2-cd1a-416e-b684-5e6dd49623e5",
+  "spec_version": "2.1",
+  "objects": [
+    {
+      "type": "x-mitre-collection",
+      "id": "x-mitre-collection--2bcdb02a-4c2b-4f64-9272-7a364f62d586",
+      "spec_version": "2.1",
+      "x_mitre_attack_spec_version": "2.1.0",
+      "name": "Sample ATT&CK Data",
+      "x_mitre_version": "1.1",
+      "description": "This collection bundle contains sample ATT&CK Data.",
+      "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+      "created": "2022-08-17T10:10:10.000Z",
+      "modified": "2022-08-18T10:10:10.000Z",
+      "object_marking_refs": [
+        "marking-definition--c2a0b8f8-51d4-4702-8e42-ce7a65235bce"
+      ],
+      "x_mitre_contents": [
+        {
+          "object_ref": "attack-pattern--757471d4-d931-4109-82dd-cdd50c04744e",
+          "object_modified": "2022-08-18T06:07:08.000Z"
+        },
+        {
+          "object_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+          "object_modified": "2017-06-01T00:00:00.000Z"
+        },
+        {
+          "object_ref": "marking-definition--c2a0b8f8-51d4-4702-8e42-ce7a65235bce",
+          "object_modified": "2020-01-01T00:00:00.000Z"
+        }
+      ]
+    },
+    {
+      "x_mitre_platforms": [
+        "Linux"
+      ],
+      "x_mitre_domains": [
+        "enterprise-attack"
+      ],
+      "object_marking_refs": [
+        "marking-definition--c2a0b8f8-51d4-4702-8e42-ce7a65235bce"
+      ],
+      "type": "attack-pattern",
+      "id": "attack-pattern--757471d4-d931-4109-82dd-cdd50c04744e",
+      "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+      "created": "2022-05-01T06:07:08.000Z",
+      "modified": "2022-08-18T06:07:08.000Z",
+      "name": "Sample Technique 1",
+      "description": "This is a sample technique with a modified description",
+      "kill_chain_phases": [
+        {
+          "kill_chain_name": "mitre-attack",
+          "phase_name": "enlil"
+        },
+        {
+          "kill_chain_name": "mitre-attack",
+          "phase_name": "nabu"
+        }
+      ],
+      "external_references": [
+        {
+          "source_name": "mitre-attack",
+          "url": "https://attack.mitre.org/techniques/TX0001",
+          "external_id": "TX0001"
+        }
+      ],
+      "x_mitre_data_sources": [],
+      "x_mitre_version": "1.0",
+      "x_mitre_attack_spec_version": "2.1.0",
+      "x_mitre_modified_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+      "spec_version": "2.1"
+    },
+    {
+      "object_marking_refs": [
+        "marking-definition--c2a0b8f8-51d4-4702-8e42-ce7a65235bce"
+      ],
+      "id": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+      "type": "identity",
+      "identity_class": "organization",
+      "created": "2017-06-01T00:00:00.000Z",
+      "modified": "2017-06-01T00:00:00.000Z",
+      "name": "The Corporate Entity",
+      "spec_version": "2.1",
+      "x_mitre_attack_spec_version": "2.1.0",
+      "x_mitre_version": "1.0"
+    },
+    {
+      "definition": {
+        "statement": "Copyright 2015-2022, The MITRE Corporation. MITRE ATT&CK and ATT&CK are registered trademarks of The MITRE Corporation."
+      },
+      "id": "marking-definition--c2a0b8f8-51d4-4702-8e42-ce7a65235bce",
+      "type": "marking-definition",
+      "created": "2020-01-01T00:00:00.000Z",
+      "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+      "definition_type": "statement",
+      "x_mitre_attack_spec_version": "2.1.0",
+      "spec_version": "2.1",
+      "x_mitre_domains": [
+        "ics-attack"
+      ]
+    }
+  ]
+}

--- a/app/tests/api/attack-objects/attack-objects.spec.js
+++ b/app/tests/api/attack-objects/attack-objects.spec.js
@@ -1,3 +1,5 @@
+const { promises: fs } = require('fs');
+
 const request = require('supertest');
 const expect = require('expect');
 
@@ -7,217 +9,20 @@ const AttackObject = require('../../../models/attack-object-model');
 const login = require('../../shared/login');
 
 const logger = require('../../../lib/logger');
+const util = require("util");
+const collectionBundlesService = require("../../../services/collection-bundles-service");
 logger.level = 'debug';
 
-// modified and created properties will be set before calling REST API
-// stix.id property will be created by REST API
-const collectionData = {
-    workspace: {
-        imported: new Date().toISOString(),
-        import_categories: {
-            additions: [],
-            changes: [],
-            minor_changes: [],
-            revocations: [],
-            deprecations: [],
-            supersedes_user_edits: [],
-            supersedes_collection_changes: [],
-            duplicates: [],
-            out_of_date: [],
-            errors: []
-        }
-    },
-    stix: {
-        id: 'x-mitre-collection--30ee11cf-0a05-4d9e-ab54-9b8563669647',
-        name: 'collection-1',
-        spec_version: '2.1',
-        type: 'x-mitre-collection',
-        description: 'This is a collection.',
-        external_references: [
-            { source_name: 'source-1', external_id: 's1' }
-        ],
-        object_marking_refs: [ 'marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168' ],
-        created_by_ref: "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
-        x_mitre_contents: []
-    }
-};
-
-const groupData = {
-    workspace: {
-        workflow: {
-            state: 'work-in-progress'
-        }
-    },
-    stix: {
-        name: 'intrusion-set-1',
-        spec_version: '2.1',
-        type: 'intrusion-set',
-        description: 'This is a group.',
-        external_references: [
-            { source_name: 'mitre-attack', external_id: 'G1111', url: 'https://attack.mitre.org/groups/G1111' },
-            { source_name: 'source-1', external_id: 's1' }
-        ],
-        object_marking_refs: [ 'marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168' ],
-        created_by_ref: "identity--6444f546-6900-4456-b3b1-015c88d70dab"
-    }
-};
-
-const identityData = {
-    workspace: {
-        workflow: {
-            state: 'work-in-progress'
-        }
-    },
-    stix: {
-        name: 'identity-1',
-        identity_class: 'organization',
-        spec_version: '2.1',
-        type: 'identity',
-        description: 'This is an identity.',
-        object_marking_refs: [ 'marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168' ]
-    }
-};
-
-const mitigationData = {
-    workspace: {
-        workflow: {
-            state: 'work-in-progress'
-        }
-    },
-    stix: {
-        name: 'course-of-action-1',
-        spec_version: '2.1',
-        type: 'course-of-action',
-        description: 'This is a mitigation.',
-        external_references: [
-            { source_name: 'mitre-attack', external_id: 'T9999', url: 'https://attack.mitre.org/mitigations/T9999' },
-            { source_name: 'source-1', external_id: 's1' }
-        ],
-        object_marking_refs: [ 'marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168' ],
-        created_by_ref: "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
-        x_mitre_version: "1.1"
-    }
-};
-
-const softwareData = {
-    workspace: {
-        workflow: {
-            state: 'work-in-progress'
-        }
-    },
-    stix: {
-        name: 'software-1',
-        spec_version: '2.1',
-        type: 'malware',
-        description: 'This is a malware type of software.',
-        is_family: false,
-        external_references: [
-            { source_name: 'mitre-attack', external_id: 'S3333', url: 'https://attack.mitre.org/software/S3333' },
-            { source_name: 'source-1', external_id: 's1' }
-        ],
-        object_marking_refs: [ 'marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168' ],
-        created_by_ref: "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
-        x_mitre_version: "1.1",
-        x_mitre_aliases: [
-            "software-1"
-        ],
-        x_mitre_platforms: [
-            "platform-1"
-        ],
-        x_mitre_contributors: [
-            "contributor-1",
-            "contributor-2"
-        ],
-        x_mitre_domains: [
-            "mobile-attack"
-        ]
-    }
-};
-
-const relationshipData = {
-    workspace: {
-        workflow: {
-            state: 'work-in-progress'
-        }
-    },
-    stix: {
-        spec_version: '2.1',
-        type: 'relationship',
-        relationship_type: 'uses',
-        source_ref: '',
-        target_ref: '',
-        object_marking_refs: [ 'marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168' ],
-        created_by_ref: "identity--6444f546-6900-4456-b3b1-015c88d70dab"
-    }
-};
-
-const tacticData = {
-    workspace: {
-        workflow: {
-            state: 'work-in-progress'
-        }
-    },
-    stix: {
-        name: 'x-mitre-tactic-1',
-        spec_version: '2.1',
-        type: 'x-mitre-tactic',
-        description: 'This is a tactic.',
-        external_references: [
-            { source_name: 'mitre-attack', external_id: 'TA4444', url: 'https://attack.mitre.org/tactics/TA4444' },
-            { source_name: 'source-1', external_id: 's1' }
-        ],
-        object_marking_refs: [ 'marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168' ],
-        created_by_ref: "identity--6444f546-6900-4456-b3b1-015c88d70dab"
-    }
-};
-
-const techniqueData = {
-    workspace: {
-        workflow: {
-            state: 'work-in-progress'
-        }
-    },
-    stix: {
-        name: 'attack-pattern-1',
-        spec_version: '2.1',
-        type: 'attack-pattern',
-        description: 'This is a technique.',
-        external_references: [
-            { source_name: 'mitre-attack', external_id: 'T9999', url: 'https://attack.mitre.org/techniques/T9999' },
-            { source_name: 'source-1', external_id: 's1' }
-        ],
-        object_marking_refs: [ 'marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168' ],
-        created_by_ref: "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
-        kill_chain_phases: [
-            { kill_chain_name: 'kill-chain-name-1', phase_name: 'phase-1' }
-        ],
-        x_mitre_data_sources: [ 'data-source-1', 'data-source-2' ],
-        x_mitre_detection: 'detection text',
-        x_mitre_is_subtechnique: false,
-        x_mitre_impact_type: [ 'impact-1' ],
-        x_mitre_platforms: [ 'platform-1', 'platform-2' ]
-    }
-};
-
-const markingDefinitionData = {
-    workspace: {
-        workflow: {
-            state: 'work-in-progress'
-        }
-    },
-    stix: {
-        spec_version: '2.1',
-        type: 'marking-definition',
-        definition_type: 'statement',
-        definition: { statement: 'This is a marking definition.' },
-        created_by_ref: "identity--6444f546-6900-4456-b3b1-015c88d70dab"
-    }
-};
+async function readJson(path) {
+    const data = await fs.readFile(require.resolve(path));
+    return JSON.parse(data);
+}
 
 describe('ATT&CK Objects API', function () {
     let app;
     let passportCookie;
 
+    const importBundle = util.promisify(collectionBundlesService.importBundle);
     before(async function() {
         // Establish the database connection
         // Use an in-memory database that we spin up for the test
@@ -232,266 +37,22 @@ describe('ATT&CK Objects API', function () {
         // Initialize the express app
         app = await require('../../../index').initializeApp();
 
+        const collectionBundle1 = await readJson('./attack-objects-1.json');
+        const collectionList1 = collectionBundle1.objects.filter(object => object.type === 'x-mitre-collection');
+
+        const importOptions = {};
+        await importBundle(collectionList1[0], collectionBundle1, importOptions);
+
+        const collectionBundle2 = await readJson('./attack-objects-2.json');
+        const collectionList2 = collectionBundle2.objects.filter(object => object.type === 'x-mitre-collection');
+
+        await importBundle(collectionList2[0], collectionBundle2, importOptions);
+
         // Log into the app
         passportCookie = await login.loginAnonymous(app);
     });
 
-    it('GET /api/attack-objects returns only the placeholder identity', function (done) {
-        request(app)
-            .get('/api/attack-objects')
-            .set('Accept', 'application/json')
-            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
-            .expect(200)
-            .expect('Content-Type', /json/)
-            .end(function(err, res) {
-                if (err) {
-                    done(err);
-                }
-                else {
-                    // We expect to get an array with the placeholder identity and the pre-defined TLP marking defintions
-                    const attackObjects = res.body;
-                    expect(attackObjects).toBeDefined();
-                    expect(Array.isArray(attackObjects)).toBe(true);
-
-                    const identities = attackObjects.filter(x => x.stix.type === 'identity');
-                    expect(identities.length).toBe(1);
-
-                    const markingDefinitions = attackObjects.filter(x => x.stix.type === 'marking-definition');
-                    expect(markingDefinitions.length).toBe(4);
-
-                    done();
-                }
-            });
-    });
-
-    it('POST /api/collections creates a collection', function (done) {
-        const timestamp = new Date().toISOString();
-        collectionData.stix.created = timestamp;
-        collectionData.stix.modified = timestamp;
-        const body = collectionData;
-        request(app)
-            .post('/api/collections')
-            .send(body)
-            .set('Accept', 'application/json')
-            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
-            .expect(201)
-            .expect('Content-Type', /json/)
-            .end(function (err, res) {
-                if (err) {
-                    done(err);
-                } else {
-                    // We expect to get the created collection
-                    const collection = res.body;
-                    expect(collection).toBeDefined();
-                    done();
-                }
-            });
-    });
-
-    let group;
-    it('POST /api/groups creates a group', function (done) {
-        const timestamp = new Date().toISOString();
-        groupData.stix.created = timestamp;
-        groupData.stix.modified = timestamp;
-        const body = groupData;
-        request(app)
-            .post('/api/groups')
-            .send(body)
-            .set('Accept', 'application/json')
-            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
-            .expect(201)
-            .expect('Content-Type', /json/)
-            .end(function(err, res) {
-                if (err) {
-                    done(err);
-                }
-                else {
-                    // We expect to get the created group
-                    group = res.body;
-                    expect(group).toBeDefined();
-
-                    done();
-                }
-            });
-    });
-
-    it('POST /api/identities creates an identity', function (done) {
-        const timestamp = new Date().toISOString();
-        identityData.stix.created = timestamp;
-        identityData.stix.modified = timestamp;
-        const body = identityData;
-        request(app)
-            .post('/api/identities')
-            .send(body)
-            .set('Accept', 'application/json')
-            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
-            .expect(201)
-            .expect('Content-Type', /json/)
-            .end(function(err, res) {
-                if (err) {
-                    done(err);
-                }
-                else {
-                    // We expect to get the created identity
-                    const identity = res.body;
-                    expect(identity).toBeDefined();
-                    done();
-                }
-            });
-    });
-
-    it('POST /api/marking-definitions creates a marking definition', function (done) {
-        const timestamp = new Date().toISOString();
-        markingDefinitionData.stix.created = timestamp;
-        const body = markingDefinitionData;
-        request(app)
-            .post('/api/marking-definitions')
-            .send(body)
-            .set('Accept', 'application/json')
-            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
-            .expect(201)
-            .expect('Content-Type', /json/)
-            .end(function(err, res) {
-                if (err) {
-                    done(err);
-                }
-                else {
-                    // We expect to get the created marking definition
-                    const markingDefinition = res.body;
-                    expect(markingDefinition).toBeDefined();
-                    done();
-                }
-            });
-    });
-
-    it('POST /api/mitigations creates a mitigation', function (done) {
-        const timestamp = new Date().toISOString();
-        mitigationData.stix.created = timestamp;
-        mitigationData.stix.modified = timestamp;
-        const body = mitigationData;
-        request(app)
-            .post('/api/mitigations')
-            .send(body)
-            .set('Accept', 'application/json')
-            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
-            .expect(201)
-            .expect('Content-Type', /json/)
-            .end(function(err, res) {
-                if (err) {
-                    done(err);
-                }
-                else {
-                    // We expect to get the created mitigation
-                    const mitigation = res.body;
-                    expect(mitigation).toBeDefined();
-                    done();
-                }
-            });
-    });
-
-    let software;
-    it('POST /api/software creates a software', function (done) {
-        const timestamp = new Date().toISOString();
-        softwareData.stix.created = timestamp;
-        softwareData.stix.modified = timestamp;
-        const body = softwareData;
-        request(app)
-            .post('/api/software')
-            .send(body)
-            .set('Accept', 'application/json')
-            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
-            .expect(201)
-            .expect('Content-Type', /json/)
-            .end(function(err, res) {
-                if (err) {
-                    done(err);
-                }
-                else {
-                    // We expect to get the created software
-                    software = res.body;
-                    expect(software).toBeDefined();
-                    done();
-                }
-            });
-    });
-
-    it('POST /api/relationship creates a relationship from the group to the software', function (done) {
-        const timestamp = new Date().toISOString();
-        relationshipData.stix.created = timestamp;
-        relationshipData.stix.modified = timestamp;
-        relationshipData.stix.source_ref = group.stix.id;
-        relationshipData.stix.target_ref = software.stix.id
-        const body = relationshipData;
-        request(app)
-            .post('/api/relationships')
-            .send(body)
-            .set('Accept', 'application/json')
-            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
-            .expect(201)
-            .expect('Content-Type', /json/)
-            .end(function(err, res) {
-                if (err) {
-                    done(err);
-                }
-                else {
-                    // We expect to get the created software
-                    const relationship = res.body;
-                    expect(relationship).toBeDefined();
-                    done();
-                }
-            });
-    });
-
-    it('POST /api/tactics creates a tactic', function (done) {
-        const timestamp = new Date().toISOString();
-        tacticData.stix.created = timestamp;
-        tacticData.stix.modified = timestamp;
-        const body = tacticData;
-        request(app)
-            .post('/api/tactics')
-            .send(body)
-            .set('Accept', 'application/json')
-            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
-            .expect(201)
-            .expect('Content-Type', /json/)
-            .end(function(err, res) {
-                if (err) {
-                    done(err);
-                }
-                else {
-                    // We expect to get the created tactic
-                    const tactic = res.body;
-                    expect(tactic).toBeDefined();
-                    done();
-                }
-            });
-    });
-
-    it('POST /api/techniques creates a technique', function (done) {
-        const timestamp = new Date().toISOString();
-        techniqueData.stix.created = timestamp;
-        techniqueData.stix.modified = timestamp;
-        const body = techniqueData;
-        request(app)
-            .post('/api/techniques')
-            .send(body)
-            .set('Accept', 'application/json')
-            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
-            .expect(201)
-            .expect('Content-Type', /json/)
-            .end(function (err, res) {
-                if (err) {
-                    done(err);
-                } else {
-                    // We expect to get the created technique
-                    const technique = res.body;
-                    expect(technique).toBeDefined();
-                    done();
-                }
-            });
-    });
-
-    it('GET /api/attack-objects returns the added ATT&CK objects', function (done) {
+    it('GET /api/attack-objects returns the ATT&CK objects imported from the collection bundles', function (done) {
         request(app)
             .get('/api/attack-objects')
             .set('Accept', 'application/json')
@@ -507,7 +68,49 @@ describe('ATT&CK Objects API', function () {
                     const attackObjects = res.body;
                     expect(attackObjects).toBeDefined();
                     expect(Array.isArray(attackObjects)).toBe(true);
-                    expect(attackObjects.length).toBe(14);
+
+                    // We expect the placeholder identity and the new collection identity
+                    const identities = attackObjects.filter(x => x.stix.type === 'identity');
+                    expect(identities.length).toBe(2);
+
+                    // We expect the 4 TLP marking definitions and the new collection identity
+                    const markingDefinitions = attackObjects.filter(x => x.stix.type === 'marking-definition');
+                    expect(markingDefinitions.length).toBe(5);
+
+                    // Placeholder identity, 4 TLP marking definitions, 17 collection contents, 1 collection object
+                    expect(attackObjects.length).toBe(1 + 4 + 17 + 1);
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/attack-objects returns all versions of the ATT&CK objects imported from the collection bundles', function (done) {
+        request(app)
+            .get('/api/attack-objects?versions=all')
+            .set('Accept', 'application/json')
+            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get ATT&CK objects in an array
+                    const attackObjects = res.body;
+                    expect(attackObjects).toBeDefined();
+                    expect(Array.isArray(attackObjects)).toBe(true);
+
+                    // We expect the placeholder identity and the new collection identity
+                    const identities = attackObjects.filter(x => x.stix.type === 'identity');
+                    expect(identities.length).toBe(2);
+
+                    // We expect the 4 TLP marking definitions and the new collection identity
+                    const markingDefinitions = attackObjects.filter(x => x.stix.type === 'marking-definition');
+                    expect(markingDefinitions.length).toBe(5);
+
+                    // Placeholder identity, 4 TLP marking definitions, 18 collection contents, 2 collection objects
+                    expect(attackObjects.length).toBe(1 + 4 + 18 + 2);
                     done();
                 }
             });
@@ -535,9 +138,9 @@ describe('ATT&CK Objects API', function () {
             });
     });
 
-    it('GET /api/attack-objects returns the group with ATT&CK ID G1111', function (done) {
+    it('GET /api/attack-objects returns the group with ATT&CK ID GX1111', function (done) {
         request(app)
-            .get('/api/attack-objects?attackId=G1111')
+            .get('/api/attack-objects?attackId=GX1111')
             .set('Accept', 'application/json')
             .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
             .expect(200)
@@ -552,16 +155,15 @@ describe('ATT&CK Objects API', function () {
                     expect(attackObjects).toBeDefined();
                     expect(Array.isArray(attackObjects)).toBe(true);
                     expect(attackObjects.length).toBe(1);
-                    const groupObject = attackObjects[0];
-                    expect(groupObject.stix.name).toBe(groupData.stix.name);
+
                     done();
                 }
             });
     });
 
-    it('GET /api/attack-objects returns the software with ATT&CK ID S3333', function (done) {
+    it('GET /api/attack-objects returns the software with ATT&CK ID SX3333', function (done) {
         request(app)
-            .get('/api/attack-objects?attackId=S3333')
+            .get('/api/attack-objects?attackId=SX3333')
             .set('Accept', 'application/json')
             .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
             .expect(200)
@@ -576,39 +178,15 @@ describe('ATT&CK Objects API', function () {
                     expect(attackObjects).toBeDefined();
                     expect(Array.isArray(attackObjects)).toBe(true);
                     expect(attackObjects.length).toBe(1);
-                    const softwareObject = attackObjects[0];
-                    expect(softwareObject.stix.name).toBe(softwareData.stix.name);
-                    expect(softwareObject.stix.x_mitre_version).toBe(softwareData.stix.x_mitre_version);
+
                     done();
                 }
             });
     });
 
-    it('GET /api/attack-objects returns the mitigation and the technique with ATT&CK ID T9999', function (done) {
+    it('GET /api/attack-objects returns the technique with ATT&CK ID TX0001', function (done) {
         request(app)
-            .get('/api/attack-objects?attackId=T9999')
-            .set('Accept', 'application/json')
-            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
-            .expect(200)
-            .expect('Content-Type', /json/)
-            .end(function(err, res) {
-                if (err) {
-                    done(err);
-                }
-                else {
-                    // We expect to get the matching objects
-                    const attackObjects = res.body;
-                    expect(attackObjects).toBeDefined();
-                    expect(Array.isArray(attackObjects)).toBe(true);
-                    expect(attackObjects.length).toBe(2);
-                    done();
-                }
-            });
-    });
-
-    it('GET /api/attack-objects uses the search parameter to return the tactic object', function (done) {
-        request(app)
-            .get('/api/attack-objects?search=tactic')
+            .get('/api/attack-objects?attackId=TX0001')
             .set('Accept', 'application/json')
             .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
             .expect(200)
@@ -623,7 +201,32 @@ describe('ATT&CK Objects API', function () {
                     expect(attackObjects).toBeDefined();
                     expect(Array.isArray(attackObjects)).toBe(true);
                     expect(attackObjects.length).toBe(1);
+
+                    done();
+                }
+            });
+    });
+
+    it('GET /api/attack-objects uses the search parameter to return the tactic objects', function (done) {
+        request(app)
+            .get('/api/attack-objects?search=nabu')
+            .set('Accept', 'application/json')
+            .set('Cookie', `${ login.passportCookieName }=${ passportCookie.value }`)
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                if (err) {
+                    done(err);
+                }
+                else {
+                    // We expect to get the matching objects
+                    const attackObjects = res.body;
+                    expect(attackObjects).toBeDefined();
+                    expect(Array.isArray(attackObjects)).toBe(true);
+                    expect(attackObjects.length).toBe(2);
                     expect(attackObjects[0].stix.type).toBe('x-mitre-tactic');
+                    expect(attackObjects[1].stix.type).toBe('x-mitre-tactic');
+
                     done();
                 }
             });


### PR DESCRIPTION
Closes #217 