### PR TITLE
Support migration scripts

### DIFF
--- a/app/config/config.js
+++ b/app/config/config.js
@@ -101,6 +101,14 @@ function loadConfig() {
                 doc: 'URL of the MongoDB server',
                 default: '',
                 env: 'DATABASE_URL'
+            },
+            migration: {
+                enable: {
+                    doc: 'Enable automatic database migration when starting the server',
+                    format: Boolean,
+                    default: true,
+                    env: 'WB_REST_DATABASE_MIGRATION_ENABLE'
+                },
             }
         },
         logging: {

--- a/app/lib/migration/migrate-database.js
+++ b/app/lib/migration/migrate-database.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const migrateMongo = require('migrate-mongo');
+const config = require('../../config/config');
+const logger = require('../logger');
+
+exports.migrateDatabase = async function() {
+    global.options = {
+        file: './app/lib/migration/migration-config.js'
+    };
+
+    const { db, client } = await migrateMongo.database.connect();
+    const migrationStatus = await migrateMongo.status(db);
+
+    const actionsPending = Boolean(migrationStatus.find(elem => elem.appliedAt === 'PENDING'));
+    if (actionsPending) {
+        if (config.database.migration.enable) {
+            logger.info('Starting database migration...');
+            const appliedActions = await migrateMongo.up(db, client);
+            for (const action of appliedActions) {
+                logger.info(`Applied migration action: ${ action }`);
+            }
+        }
+        else {
+            await client.close();
+            throw new Error('One or more database migration actions are pending, but database migrations are disabled');
+        }
+    }
+    else {
+        logger.info('No pending database migration actions found');
+    }
+
+    await client.close();
+};

--- a/app/lib/migration/migration-config.js
+++ b/app/lib/migration/migration-config.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const config = require('../../config/config');
+
+module.exports = {
+    mongodb: {
+        url: config.database.url,
+
+        options: {
+            useNewUrlParser: true
+        }
+    },
+
+    // The migrations dir, can be an relative or absolute path. Only edit this when really necessary.
+    migrationsDir: "migrations",
+
+    // The mongodb collection where the applied changes are stored. Only edit this when really necessary.
+    changelogCollectionName: "changelog",
+
+    // The file extension to create migrations and search for in migration dir
+    migrationFileExtension: ".js",
+
+    // Enable the algorithm to create a checksum of the file contents and use that in the comparison to determine
+    // if the file should be run.  Requires that scripts are coded to be run multiple times.
+    useFileHash: false
+};

--- a/bin/www
+++ b/bin/www
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+const errors = {
+    noDatabaseConnection: 'No database connection',
+    databaseMigrationFailed: 'Database migration failed'
+};
+
 async function runServer() {
     // Configure the logger
     const logger = require('../app/lib/logger');
@@ -17,13 +22,27 @@ async function runServer() {
     logger.info(`Log level set to ${ config.logging.logLevel }`);
 
     // Establish the database connection
-    logger.info('Setting up the database connection');
+    logger.info('Setting up the database connection...');
     try {
         await require('../app/lib/database-connection').initializeConnection();
     }
     catch(err) {
-        logger.error('Unable to connect to database: ' + err);
-        throw new Error('Database connection is required. Terminating app.');
+        logger.error('Unable to connect to database');
+        logger.error(err.message);
+        logger.error('Database connection is required; terminating app');
+        throw new Error(errors.noDatabaseConnection);
+    }
+
+    // Apply any database migration actions required
+    const migrateDatabase = require('../app/lib/migration/migrate-database');
+    try {
+        await migrateDatabase.migrateDatabase();
+    }
+    catch (err) {
+        logger.error('Unable to perform database migration');
+        logger.error(err.message);
+        logger.error('Database migration is required; terminating app');
+        throw new Error(errors.databaseMigrationFailed);
     }
 
     // Check for valid database configuration
@@ -34,13 +53,22 @@ async function runServer() {
     const app = await require('../app').initializeApp();
 
     // Start the server
-    logger.info('Starting the HTTP server');
+    logger.info('Starting the HTTP server...');
     const server = app.listen(config.server.port, function () {
         const host = server.address().address;
         const port = server.address().port;
 
         logger.info(`Listening at http://${host}:${port}`);
         logger.info('ATT&CK Workbench REST API start up complete');
+    });
+
+    server.on('error', function(err) {
+        if (err.code === 'EADDRINUSE') {
+            logger.error('Unable to start the HTTP server');
+            logger.error(err.message);
+            logger.error('HTTP server is required; terminating app');
+            // Don't need to throw error, this error is automatically raised to the calling function
+        }
     });
 
     // Listen for a ctrl-c
@@ -68,8 +96,16 @@ runServer()
         process.exit();
     })
     .catch(err => {
-        console.log('runServer() - Unexpected error:');
-        console.log(err.message);
-        console.log(err.stack);
+        if (err.code === 'EADDRINUSE' || Object.values(errors).includes(err.message)) {
+            // Trap the explicitly handled errors
+            console.error('runServer() - Terminating after error');
+        }
+        else {
+            // Trap and log any other error
+            console.error('runServer() - Terminating after unexpected error:');
+            console.error(err.message);
+            console.error(err.stack);
+        }
+
         process.exit(1);
     });

--- a/migrations/20220705205741-move-relationships.js
+++ b/migrations/20220705205741-move-relationships.js
@@ -1,0 +1,55 @@
+'use strict';
+
+module.exports = {
+    async up(db, client) {
+        const attackObjectsCollection = await db.collection('attackObjects');
+        const relationshipsCollection = await db.collection('relationships');
+
+        // Move relationship objects from the attackObjects collection to the relationships collection
+        const oldRelationships = await attackObjectsCollection.find({ '__t': 'relationship' }).toArray();
+
+        for (const relationship of oldRelationships) {
+            // The relationship should not exist in the relationships collection
+            const newRelationship = await relationshipsCollection.find({ 'stix.id': relationship.stix.id, 'stix.modified': relationship.stix.modified });
+            if (newRelationship) {
+                console.warning('Relationship already exists in relationships collection. Will delete from attackObjects collection without adding to relationships collection.');
+                attackObjectsCollection.findOneAndDelete({ 'stix.id': relationship.stix.id, 'stix.modified': relationship.stix.modified });
+            }
+            else {
+                // Add the relationship to the relationships collection
+                relationship._id = undefined;
+                relationship.__t = undefined;
+                relationshipsCollection.insert(relationship);
+
+                // Remove the relationship from the attackObjects collection
+                attackObjectsCollection.findOneAndDelete({ 'stix.id': relationship.stix.id, 'stix.modified': relationship.stix.modified });
+            }
+        }
+    },
+
+    async down(db, client) {
+        const attackObjectsCollection = await db.collection('attackObjects');
+        const relationshipsCollection = await db.collection('relationships');
+
+        // Move relationship objects from the relationship collection to the attackObjects collection
+        const newRelationships = await relationshipsCollection.find({ }).toArray();
+
+        for (const relationship of newRelationships) {
+            // The relationship should not exist in the attackObjects collection
+            const oldRelationship = await attackObjectsCollection.find({ 'stix.id': relationship.stix.id, 'stix.modified': relationship.stix.modified });
+            if (oldRelationship) {
+                console.warning('Relationship already exists in attackObjects collection. Will delete from attackObjects collection without adding to attackObjects collection.');
+                relationshipsCollection.findOneAndDelete({ 'stix.id': relationship.stix.id, 'stix.modified': relationship.stix.modified });
+            }
+            else {
+                // Add the relationship to the attackObjects collection
+                relationship._id = undefined;
+                relationship.__t = undefined;
+                attackObjectsCollection.insert(relationship);
+
+                // Remove the relationship from the relationships collection
+                relationshipsCollection.findOneAndDelete({ 'stix.id': relationship.stix.id, 'stix.modified': relationship.stix.modified });
+            }
+        }
+    }
+};

--- a/migrations/20220705205741-move-relationships.js
+++ b/migrations/20220705205741-move-relationships.js
@@ -6,20 +6,22 @@ module.exports = {
         const relationshipsCollection = await db.collection('relationships');
 
         // Move relationship objects from the attackObjects collection to the relationships collection
-        const oldRelationships = await attackObjectsCollection.find({ '__t': 'relationship' }).toArray();
+        const oldRelationships = await attackObjectsCollection.find({ '__t': 'RelationshipModel' }).toArray();
+        console.log(`Found ${ oldRelationships.length } relationships in the attackObjects collection`);
 
         for (const relationship of oldRelationships) {
             // The relationship should not exist in the relationships collection
-            const newRelationship = await relationshipsCollection.find({ 'stix.id': relationship.stix.id, 'stix.modified': relationship.stix.modified });
+            const newRelationship = await relationshipsCollection.findOne({ 'stix.id': relationship.stix.id, 'stix.modified': relationship.stix.modified });
             if (newRelationship) {
-                console.warning('Relationship already exists in relationships collection. Will delete from attackObjects collection without adding to relationships collection.');
+                console.log('Relationship already exists in relationships collection. Will delete from attackObjects collection without adding to relationships collection.');
                 attackObjectsCollection.findOneAndDelete({ 'stix.id': relationship.stix.id, 'stix.modified': relationship.stix.modified });
             }
             else {
+//                console.log(`Moving relationships ${ relationship.stix.id }/${ relationship.stix.modified }`);
                 // Add the relationship to the relationships collection
                 relationship._id = undefined;
                 relationship.__t = undefined;
-                relationshipsCollection.insert(relationship);
+                relationshipsCollection.insertOne(relationship);
 
                 // Remove the relationship from the attackObjects collection
                 attackObjectsCollection.findOneAndDelete({ 'stix.id': relationship.stix.id, 'stix.modified': relationship.stix.modified });
@@ -33,19 +35,20 @@ module.exports = {
 
         // Move relationship objects from the relationship collection to the attackObjects collection
         const newRelationships = await relationshipsCollection.find({ }).toArray();
+        console.log(`Found ${ newRelationships.length } relationships in the relationships collection`);
 
         for (const relationship of newRelationships) {
             // The relationship should not exist in the attackObjects collection
-            const oldRelationship = await attackObjectsCollection.find({ 'stix.id': relationship.stix.id, 'stix.modified': relationship.stix.modified });
+            const oldRelationship = await attackObjectsCollection.findOne({ 'stix.id': relationship.stix.id, 'stix.modified': relationship.stix.modified });
             if (oldRelationship) {
-                console.warning('Relationship already exists in attackObjects collection. Will delete from attackObjects collection without adding to attackObjects collection.');
+                console.log('Relationship already exists in attackObjects collection. Will delete from attackObjects collection without adding to attackObjects collection.');
                 relationshipsCollection.findOneAndDelete({ 'stix.id': relationship.stix.id, 'stix.modified': relationship.stix.modified });
             }
             else {
                 // Add the relationship to the attackObjects collection
                 relationship._id = undefined;
-                relationship.__t = undefined;
-                attackObjectsCollection.insert(relationship);
+                relationship.__t = 'RelationshipModel';
+                attackObjectsCollection.insertOne(relationship);
 
                 // Remove the relationship from the relationships collection
                 relationshipsCollection.findOneAndDelete({ 'stix.id': relationship.stix.id, 'stix.modified': relationship.stix.modified });

--- a/migrations/sample-migration.js
+++ b/migrations/sample-migration.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+    async up(db, client) {
+        // TODO write your migration here.
+        // See https://github.com/seppevs/migrate-mongo/#creating-a-new-migration-script
+        // Example:
+        // await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: true}});
+    },
+
+    async down(db, client) {
+        // TODO write the statements to rollback your migration (if possible)
+        // Example:
+        // await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: false}});
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -475,6 +475,12 @@
         }
       }
     },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "optional": true
+    },
     "@dabh/diagnostics": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
@@ -765,6 +771,20 @@
       "integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==",
       "dev": true
     },
+    "@types/webidl-conversions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
     "@types/yargs": {
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.12.tgz",
@@ -863,8 +883,7 @@
     "ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -954,8 +973,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -1048,7 +1066,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -1204,6 +1221,15 @@
         "timers-ext": "^0.1.7"
       }
     },
+    "cli-table3": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
+      "integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
+      "requires": {
+        "@colors/colors": "1.5.0",
+        "string-width": "^4.2.0"
+      }
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -1292,6 +1318,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
+      "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -1440,6 +1471,11 @@
         "type": "^1.0.1"
       }
     },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1551,8 +1587,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "enabled": {
       "version": "2.0.0",
@@ -2145,6 +2180,11 @@
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
     },
+    "fn-args": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fn-args/-/fn-args-5.0.0.tgz",
+      "integrity": "sha512-CtbfI3oFFc3nbdIoHycrfbrxiGgxXBXXuyOl49h47JawM1mYrqpiRqnH5CB2mBatdXvHHOUO6a+RiAuuvKt0lw=="
+    },
     "fn.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
@@ -2198,6 +2238,16 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
+    },
+    "fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2283,8 +2333,7 @@
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "growl": {
       "version": "1.10.5",
@@ -2409,8 +2458,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -2462,6 +2510,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ip": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
+      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
     },
     "ipaddr.js": {
       "version": "1.9.0",
@@ -2802,6 +2855,15 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
       }
     },
     "jsonwebtoken": {
@@ -3145,6 +3207,48 @@
         "picomatch": "^2.0.5"
       }
     },
+    "migrate-mongo": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/migrate-mongo/-/migrate-mongo-9.0.0.tgz",
+      "integrity": "sha512-Hs+5kmNdYtKo5574pvIxRAgHUkWtoXE0pIC5QPMCY1m7kwUVViuCtvOZQo0rd9rirtbI9+WDpYtI5ceG32Prgw==",
+      "requires": {
+        "cli-table3": "^0.6.1",
+        "commander": "^9.1.0",
+        "date-fns": "^2.28.0",
+        "fn-args": "^5.0.0",
+        "fs-extra": "^10.0.1",
+        "lodash": "^4.17.21",
+        "mongodb": "^4.4.1",
+        "p-each-series": "^2.2.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "4.6.4",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.4.tgz",
+          "integrity": "sha512-TdQ3FzguAu5HKPPlr0kYQCyrYUYh8tFM+CMTpxjNzVzxeiJY00Rtuj3LXLHSgiGvmaWlZ8PE+4KyM2thqE38pQ==",
+          "requires": {
+            "buffer": "^5.6.0"
+          }
+        },
+        "denque": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+          "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
+        },
+        "mongodb": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.7.0.tgz",
+          "integrity": "sha512-HhVar6hsUeMAVlIbwQwWtV36iyjKd9qdhY+s4wcU8K6TOj4Q331iiMy+FoPuxEntDIijTYWivwFJkLv8q/ZgvA==",
+          "requires": {
+            "bson": "^4.6.3",
+            "denque": "^2.0.1",
+            "mongodb-connection-string-url": "^2.5.2",
+            "saslprep": "^1.0.3",
+            "socks": "^2.6.2"
+          }
+        }
+      }
+    },
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -3348,6 +3452,39 @@
         "optional-require": "^1.0.2",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.2.tgz",
+      "integrity": "sha512-tWDyIG8cQlI5k3skB6ywaEA5F9f5OntrKKsT/Lteub2zgwSUlhqEN2inGgBTm8bpYJf8QYBdA/5naz65XDpczA==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+        },
+        "whatwg-url": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
       }
     },
     "mongodb-memory-server": {
@@ -3827,6 +3964,11 @@
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
       }
+    },
+    "p-each-series": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA=="
     },
     "p-limit": {
       "version": "2.3.0",
@@ -4364,11 +4506,25 @@
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
     "snyk": {
       "version": "1.947.0",
       "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.947.0.tgz",
       "integrity": "sha512-/u+HyhaIaFhnrpn+aOiGR0ts9ZR7mr6uiqgRn5EQIwaFKpCFOEnOJTlQAM25ggomqmxRldArMMXe4dBWw855LA==",
       "dev": true
+    },
+    "socks": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.2.0"
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -4449,7 +4605,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
       "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4459,8 +4614,7 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         }
       }
     },
@@ -4476,7 +4630,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.0"
       }
@@ -4843,6 +4996,11 @@
       "requires": {
         "random-bytes": "~1.0.0"
       }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -949,9 +949,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "jwks-rsa": "^2.0.5",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
+    "migrate-mongo": "^9.0.0",
     "mongoose": "^5.13.10",
     "morgan": "^1.10.0",
     "nanoid": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.9",
+    "ansi-regex": "^5.0.1",
     "async": "^3.2.3",
     "async-await-retry": "^1.2.3",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
Add support for migration scripts that run when the REST API service starts up. Track which migration scripts have been applied.

Closes #181 