### PR TITLE
Retrieve deprecated and revoked data components for the selected data source

### DIFF
--- a/app/services/data-sources-service.js
+++ b/app/services/data-sources-service.js
@@ -146,15 +146,15 @@ async function addDataComponents(dataSource) {
     // version doesn't.
 
     // Retrieve the latest version of all data components
-    const allDataComponents = await dataComponentsService.retrieveAllAsync({ });
+    const allDataComponents = await dataComponentsService.retrieveAllAsync({ includeDeprecated: true, includeRevoked: true });
 
     // Add the data components that reference the data source
     dataSource.dataComponents = allDataComponents.filter(dataComponent => dataComponent.stix.x_mitre_data_source_ref === dataSource.stix.id);
 }
 
 exports.retrieveById = function(stixId, options, callback) {
-    // versions=all Retrieve all data sources with the stixId
-    // versions=latest Retrieve the data sources with the latest modified date for this stixId
+    // versions=all    Retrieve all versions of the data source with the stixId
+    // versions=latest Retrieve the data source with the latest modified date for this stixId
 
     if (!stixId) {
         const error = new Error(errors.missingParameter);
@@ -215,7 +215,7 @@ exports.retrieveById = function(stixId, options, callback) {
 };
 
 exports.retrieveVersionById = function(stixId, modified, options, callback) {
-    // Retrieve the versions of the data source with the matching stixId and modified date
+    // Retrieve the version of the data source with the matching stixId and modified date
 
     if (!stixId) {
         const error = new Error(errors.missingParameter);
@@ -247,7 +247,6 @@ exports.retrieveVersionById = function(stixId, modified, options, callback) {
                     .then(() => callback(null, dataSource));
             }
             else {
-                console.log('** NOT FOUND')
                 return callback();
             }
         }

--- a/app/tests/api/data-sources/data-sources.spec.js
+++ b/app/tests/api/data-sources/data-sources.spec.js
@@ -15,7 +15,7 @@ logger.level = 'debug';
 
 // modified and created properties will be set before calling REST API
 // stix.id property will be created by REST API
-const initialObjectData = {
+const initialDataSourceData = {
     workspace: {
         workflow: {
             state: 'work-in-progress'
@@ -94,6 +94,20 @@ async function loadDataComponents(baseDataComponent) {
     data3.stix.created = timestamp;
     data3.stix.modified = timestamp;
     await dataComponentsService.create(data3);
+
+    const data4 = _.cloneDeep(baseDataComponent);
+    timestamp = new Date().toISOString();
+    data4.stix.created = timestamp;
+    data4.stix.modified = timestamp;
+    data4.stix.x_mitre_deprecated = true;
+    await dataComponentsService.create(data4);
+
+    const data5 = _.cloneDeep(baseDataComponent);
+    timestamp = new Date().toISOString();
+    data5.stix.created = timestamp;
+    data5.stix.modified = timestamp;
+    data5.stix.revoked = true;
+    await dataComponentsService.create(data5);
 }
 
 describe('Data Sources API', function () {
@@ -158,9 +172,9 @@ describe('Data Sources API', function () {
     let dataSource1;
     it('POST /api/data-sources creates a data source', function (done) {
         const timestamp = new Date().toISOString();
-        initialObjectData.stix.created = timestamp;
-        initialObjectData.stix.modified = timestamp;
-        const body = initialObjectData;
+        initialDataSourceData.stix.created = timestamp;
+        initialDataSourceData.stix.modified = timestamp;
+        const body = initialDataSourceData;
         request(app)
             .post('/api/data-sources')
             .send(body)
@@ -279,9 +293,9 @@ describe('Data Sources API', function () {
         const dataSource = dataSources[0];
         expect(dataSource).toBeDefined();
 
-        // We expect to get 3 data components that reference this data source
+        // We expect to get 5 data components that reference this data source
         expect(dataSource.dataComponents).toBeDefined();
-        expect(dataSource.dataComponents.length).toBe(3);
+        expect(dataSource.dataComponents.length).toBe(5);
     });
 
     it('PUT /api/data-sources updates a data source', function (done) {


### PR DESCRIPTION
When retrieving data sources with the `retrieveDataComponents=true` query parameter, the data source service adds related data components to the result. This PR modifies the service to include deprecated and revoked data components when adding related data components to the data source.

Closes #242 