### PR TITLE
Publish Docker image with semver tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,52 @@
-name: publish
+name: Build and Publish Docker Image
 
 on:
   push:
-    branches: [master, develop]
+    branches:
+        - "main"
+        - "develop"
+    tags:
+      - "v*.*.*"
 
 jobs:
-  publish-docker-image:
+  docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout the repository
+      -
+        name: Checkout
         uses: actions/checkout@v3
-
-      - name: Build and publish the Docker image
-        run: |
-          echo $GITHUB_TOKEN | docker login ghcr.io -u center-for-threat-informed-defense --password-stdin
-          docker build . --tag ghcr.io/center-for-threat-informed-defense/attack-workbench-rest-api:$IMAGE_TAG
-          docker push ghcr.io/center-for-threat-informed-defense/attack-workbench-rest-api:$IMAGE_TAG
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGE_TAG: "${{ github.ref == 'refs/head/master' && 'latest' || 'develop' }}"
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/center-for-threat-informed-defense/attack-workbench-rest-api
+          tags: |
+            # set latest tag for master branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+            # set develop tag for develop branch
+            type=ref,event=branch,enable=${{ github.ref == format('refs/heads/{0}', 'develop') }}
+            # set semver tag (vX.Y.Z) on git tag event
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+            # set git short commit as Docker tag (e.g., sha-ad132f5)
+            type=sha
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Closes #268 

This change enhances the existing [publish.yml](https://github.com/center-for-threat-informed-defense/attack-workbench-rest-api/blob/master/.github/workflows/publish.yml) workflow to additionally tag the published Docker image with a semver string when a git tag event occurs.

In other words, when you `git tag v1.3.1 && git push --tags` then [ghcr.io/center-for-threat-informed-defense/attack-workbench-rest-api:v1.3.1]() should be published.

The existing workflows are unaffected and will remain enabled:
- Docker tag `latest` will follow the `master` branch
- Docker tag `develop` will follow the `develop` branch