### PR TITLE
Bug fix: duplicate names in matrix tactics

### DIFF
--- a/app/services/matrices-service.js
+++ b/app/services/matrices-service.js
@@ -281,7 +281,7 @@ exports.retrieveTechniquesForMatrix = function(stixId, modified, callback) {
                         }
                         // Add techniques to tactic & store tactic
                         tactic.techniques = parentTechniques;
-                        tacticsTechniques[tactic.stix.name] = tactic;
+                        tacticsTechniques[tactic.stix.id] = tactic;
                     }
                 }
                 return callback(null, tacticsTechniques);


### PR DESCRIPTION
Fixes an issue with retrieving tactics and techniques within a matrix when it contains tactics with duplicate names.

The matrix service builds the matrix by tactic, sequentially retrieving each tactic object and its techniques, and then maps the tactics by name (rather than by a unique ID). This causes subsequent tactics to be re-mapped/overwrite previous tactics with the same name and the matrix does not build as expected on the front end (appearing to have missing tactics/techniques).