### PR TITLE
295 refactor recent activity service for improved structure and asynchronicity

### DIFF
--- a/app/exceptions/index.js
+++ b/app/exceptions/index.js
@@ -170,15 +170,10 @@ class InvalidTypeError extends CustomError {
   }
 }
 
-class MissingUpdateParameterError extends CustomError {
-  constructor(options) {
-    super('The update parameter is missing.', options);
-  }
-}
-
 module.exports = {
   //** General errors */
   NotImplementedError,
+  InvalidTypeError,
 
   //** User-related errors */
   MissingParameterError,
@@ -211,7 +206,4 @@ module.exports = {
   OrganizationIdentityNotFoundError,
   AnonymousUserAccountNotSetError,
   AnonymousUserAccountNotFoundError,
-  MissingUpdateParameterError,
-
-  InvalidTypeError,
 };

--- a/app/repository/attack-objects-repository.js
+++ b/app/repository/attack-objects-repository.js
@@ -4,7 +4,7 @@ const BaseRepository = require('./_base.repository');
 const AttackObject = require('../models/attack-object-model');
 const { lastUpdatedByQueryHelper } = require('../lib/request-parameter-helper');
 const {
-  MissingUpdateParameterError,
+  MissingParameterError,
   BadlyFormattedParameterError,
   DuplicateIdError,
   DatabaseError,
@@ -124,7 +124,9 @@ class AttackObjectsRepository extends BaseRepository {
   async findByIdAndUpdate(documentId, update) {
     try {
       if (!update) {
-        throw new MissingUpdateParameterError();
+        throw new MissingParameterError(
+          'The "update" parameter is missing. Cannot find and update document without an "update" parameter.',
+        );
       }
       return await this.model.findByIdAndUpdate(documentId, update).exec();
     } catch (err) {

--- a/app/repository/attack-objects-repository.js
+++ b/app/repository/attack-objects-repository.js
@@ -124,9 +124,7 @@ class AttackObjectsRepository extends BaseRepository {
   async findByIdAndUpdate(documentId, update) {
     try {
       if (!update) {
-        throw new MissingParameterError(
-          'The "update" parameter is missing. Cannot find and update document without an "update" parameter.',
-        );
+        throw new MissingParameterError({ parameterName: 'update' });
       }
       return await this.model.findByIdAndUpdate(documentId, update).exec();
     } catch (err) {

--- a/app/repository/recent-activity-repository.js
+++ b/app/repository/recent-activity-repository.js
@@ -1,76 +1,75 @@
 'use strict';
 
 const AttackObject = require('../models/attack-object-model');
-const RelationshipModel = require("../models/relationship-model");
+const RelationshipModel = require('../models/relationship-model');
 
 class RecentActivityRepository {
+  constructor(attackObjectModel, relationshipModel) {
+    this.attackObjectModel = attackObjectModel;
+    this.relationshipModel = relationshipModel;
+  }
 
-    constructor(attackObjectModel, relationshipModel) {
-        this.attackObjectModel = attackObjectModel;
-        this.relationshipModel = relationshipModel;
+  async retrieveAll() {
+    // Build the query
+    const query = {};
+    if (!options.includeRevoked) {
+      query['stix.revoked'] = { $in: [null, false] };
+    }
+    if (!options.includeDeprecated) {
+      query['stix.x_mitre_deprecated'] = { $in: [null, false] };
+    }
+    if (typeof options.lastUpdatedBy !== 'undefined') {
+      query['workspace.workflow.created_by_user_account'] = lastUpdatedByQueryHelper(
+        options.lastUpdatedBy,
+      );
     }
 
-    async retrieveAll() {
-        // Build the query
-        const query = {};
-        if (!options.includeRevoked) {
-            query['stix.revoked'] = { $in: [null, false] };
-        }
-        if (!options.includeDeprecated) {
-            query['stix.x_mitre_deprecated'] = { $in: [null, false] };
-        }
-        if (typeof options.lastUpdatedBy !== 'undefined') {
-            query['workspace.workflow.created_by_user_account'] = lastUpdatedByQueryHelper(
-                options.lastUpdatedBy,
-            );
-        }
+    // Filter out objects without modified dates (incl. Marking Definitions & Identities)
+    query['stix.modified'] = { $exists: true };
 
-        // Filter out objects without modified dates (incl. Marking Definitions & Identities)
-        query['stix.modified'] = { $exists: true };
+    // Build the aggregation
+    const aggregation = [];
 
-        // Build the aggregation
-        const aggregation = [];
+    // Sort objects by last modified
+    aggregation.push({ $sort: { 'stix.modified': -1 } });
 
-        // Sort objects by last modified
-        aggregation.push({ $sort: { 'stix.modified': -1 } });
-
-        // Limit documents to prevent memory issues
-        const limit = options.limit ?? 0;
-        if (limit) {
-            aggregation.push({ $limit: limit });
-        }
-
-        // Then apply query, skip and limit options
-        aggregation.push({ $match: query });
-
-        // Retrieve the documents
-        const objectDocuments = await this.attackObjectModel.aggregate(aggregation);
-
-        // Lookup source/target refs for relationships
-        aggregation.push({
-            $lookup: {
-                from: 'attackObjects',
-                localField: 'stix.source_ref',
-                foreignField: 'stix.id',
-                as: 'source_objects',
-            },
-        });
-        aggregation.push({
-            $lookup: {
-                from: 'attackObjects',
-                localField: 'stix.target_ref',
-                foreignField: 'stix.id',
-                as: 'target_objects',
-            },
-        });
-        const relationshipDocuments = await this.relationshipModel.aggregate(aggregation);
-        const documents = objectDocuments.concat(relationshipDocuments);
-
-        // Sort by most recent
-        documents.sort((a, b) => b.stix.modified - a.stix.modified)
-
-        return documents;
+    // Limit documents to prevent memory issues
+    const limit = options.limit ?? 0;
+    if (limit) {
+      aggregation.push({ $limit: limit });
     }
+
+    // Then apply query, skip and limit options
+    aggregation.push({ $match: query });
+
+    // Retrieve the documents
+    const objectDocuments = await this.attackObjectModel.aggregate(aggregation);
+
+    // Lookup source/target refs for relationships
+    aggregation.push({
+      $lookup: {
+        from: 'attackObjects',
+        localField: 'stix.source_ref',
+        foreignField: 'stix.id',
+        as: 'source_objects',
+      },
+    });
+    aggregation.push({
+      $lookup: {
+        from: 'attackObjects',
+        localField: 'stix.target_ref',
+        foreignField: 'stix.id',
+        as: 'target_objects',
+      },
+    });
+    const relationshipDocuments = await this.relationshipModel.aggregate(aggregation);
+    const documents = objectDocuments.concat(relationshipDocuments);
+
+    // Sort by most recent
+    documents.sort((a, b) => b.stix.modified - a.stix.modified);
+
+    return documents;
+  }
 }
 
-module.exports = new RecentActivityRepository(AttackObject, RelationshipModel)
+module.exports = new RecentActivityRepository(AttackObject, RelationshipModel);

--- a/app/repository/recent-activity-repository.js
+++ b/app/repository/recent-activity-repository.js
@@ -2,6 +2,7 @@
 
 const AttackObject = require('../models/attack-object-model');
 const RelationshipModel = require('../models/relationship-model');
+const { lastUpdatedByQueryHelper } = require('../lib/request-parameter-helper');
 
 class RecentActivityRepository {
   constructor(attackObjectModel, relationshipModel) {
@@ -9,7 +10,7 @@ class RecentActivityRepository {
     this.relationshipModel = relationshipModel;
   }
 
-  async retrieveAll() {
+  async retrieveAll(options) {
     // Build the query
     const query = {};
     if (!options.includeRevoked) {

--- a/app/repository/recent-activity-repository.js
+++ b/app/repository/recent-activity-repository.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const AttackObject = require('../models/attack-object-model');
+const RelationshipModel = require("../models/relationship-model");
+
+class RecentActivityRepository {
+
+    constructor(attackObjectModel, relationshipModel) {
+        this.attackObjectModel = attackObjectModel;
+        this.relationshipModel = relationshipModel;
+    }
+
+    async retrieveAll() {
+        // Build the query
+        const query = {};
+        if (!options.includeRevoked) {
+            query['stix.revoked'] = { $in: [null, false] };
+        }
+        if (!options.includeDeprecated) {
+            query['stix.x_mitre_deprecated'] = { $in: [null, false] };
+        }
+        if (typeof options.lastUpdatedBy !== 'undefined') {
+            query['workspace.workflow.created_by_user_account'] = lastUpdatedByQueryHelper(
+                options.lastUpdatedBy,
+            );
+        }
+
+        // Filter out objects without modified dates (incl. Marking Definitions & Identities)
+        query['stix.modified'] = { $exists: true };
+
+        // Build the aggregation
+        const aggregation = [];
+
+        // Sort objects by last modified
+        aggregation.push({ $sort: { 'stix.modified': -1 } });
+
+        // Limit documents to prevent memory issues
+        const limit = options.limit ?? 0;
+        if (limit) {
+            aggregation.push({ $limit: limit });
+        }
+
+        // Then apply query, skip and limit options
+        aggregation.push({ $match: query });
+
+        // Retrieve the documents
+        const objectDocuments = await this.attackObjectModel.aggregate(aggregation);
+
+        // Lookup source/target refs for relationships
+        aggregation.push({
+            $lookup: {
+                from: 'attackObjects',
+                localField: 'stix.source_ref',
+                foreignField: 'stix.id',
+                as: 'source_objects',
+            },
+        });
+        aggregation.push({
+            $lookup: {
+                from: 'attackObjects',
+                localField: 'stix.target_ref',
+                foreignField: 'stix.id',
+                as: 'target_objects',
+            },
+        });
+        const relationshipDocuments = await this.relationshipModel.aggregate(aggregation);
+        const documents = objectDocuments.concat(relationshipDocuments);
+
+        // Sort by most recent
+        documents.sort((a, b) => b.stix.modified - a.stix.modified)
+
+        return documents;
+    }
+}
+
+module.exports = new RecentActivityRepository(AttackObject, RelationshipModel)

--- a/app/services/attack-objects-service.js
+++ b/app/services/attack-objects-service.js
@@ -136,7 +136,7 @@ class AttackObjectsService extends BaseService {
       throw DatabaseError(err);
     }
   }
-  
+
   async retrieveOneByVersionLean(stixId, stixModified) {
     try {
       return await this.repository.retrieveOneByVersionLean(stixId, stixModified);

--- a/app/services/recent-activity-service.js
+++ b/app/services/recent-activity-service.js
@@ -1,125 +1,68 @@
 'use strict';
 
-const AttackObject = require('../models/attack-object-model');
-const Relationship = require('../models/relationship-model');
+const recentActivityRepository = require('../repository/recent-activity-repository');
 const identitiesService = require('./identities-service');
 
-const { lastUpdatedByQueryHelper } = require('../lib/request-parameter-helper');
+class RecentActivityService {
 
-const errors = {
-  missingParameter: 'Missing required parameter',
-  badlyFormattedParameter: 'Badly formatted parameter',
-  duplicateId: 'Duplicate id',
-  notFound: 'Document not found',
-  invalidQueryStringParameter: 'Invalid query string parameter',
-  duplicateCollection: 'Duplicate collection',
-};
-exports.errors = errors;
-
-exports.retrieveAll = async function (options) {
-  // Build the query
-  const query = {};
-  if (!options.includeRevoked) {
-    query['stix.revoked'] = { $in: [null, false] };
-  }
-  if (!options.includeDeprecated) {
-    query['stix.x_mitre_deprecated'] = { $in: [null, false] };
-  }
-  if (typeof options.lastUpdatedBy !== 'undefined') {
-    query['workspace.workflow.created_by_user_account'] = lastUpdatedByQueryHelper(
-      options.lastUpdatedBy,
-    );
+  constructor(repository) {
+    this.repository = repository;
   }
 
-  // Filter out objects without modified dates (incl. Marking Definitions & Identities)
-  query['stix.modified'] = { $exists: true };
+  async retrieveAll(options) {
+    const documents = this.repository.retrieveAll(options);
 
-  // Build the aggregation
-  const aggregation = [];
+    // Sort by most recent
+    documents.sort((a, b) => b.stix.modified - a.stix.modified);
 
-  // Sort objects by last modified
-  aggregation.push({ $sort: { 'stix.modified': -1 } });
+    // Move latest source and target objects to a non-array property, then remove array of source and target objects
+    for (const document of documents) {
+      if (Array.isArray(document.source_objects)) {
+        if (document.source_objects.length === 0) {
+          document.source_objects = undefined;
+        } else {
+          document.source_object = document.source_objects[0];
+          document.source_objects = undefined;
+        }
+      }
 
-  // Limit documents to prevent memory issues
-  const limit = options.limit ?? 0;
-  if (limit) {
-    aggregation.push({ $limit: limit });
-  }
-
-  // Then apply query, skip and limit options
-  aggregation.push({ $match: query });
-
-  // Retrieve the documents
-  const objectDocuments = await AttackObject.aggregate(aggregation);
-
-  // Lookup source/target refs for relationships
-  aggregation.push({
-    $lookup: {
-      from: 'attackObjects',
-      localField: 'stix.source_ref',
-      foreignField: 'stix.id',
-      as: 'source_objects',
-    },
-  });
-  aggregation.push({
-    $lookup: {
-      from: 'attackObjects',
-      localField: 'stix.target_ref',
-      foreignField: 'stix.id',
-      as: 'target_objects',
-    },
-  });
-  const relationshipDocuments = await Relationship.aggregate(aggregation);
-  const documents = objectDocuments.concat(relationshipDocuments);
-
-  // Sort by most recent
-  documents.sort((a, b) => b.stix.modified - a.stix.modified);
-
-  // Move latest source and target objects to a non-array property, then remove array of source and target objects
-  for (const document of documents) {
-    if (Array.isArray(document.source_objects)) {
-      if (document.source_objects.length === 0) {
-        document.source_objects = undefined;
-      } else {
-        document.source_object = document.source_objects[0];
-        document.source_objects = undefined;
+      if (Array.isArray(document.target_objects)) {
+        if (document.target_objects.length === 0) {
+          document.target_objects = undefined;
+        } else {
+          document.target_object = document.target_objects[0];
+          document.target_objects = undefined;
+        }
       }
     }
 
-    if (Array.isArray(document.target_objects)) {
-      if (document.target_objects.length === 0) {
-        document.target_objects = undefined;
-      } else {
-        document.target_object = document.target_objects[0];
-        document.target_objects = undefined;
-      }
+    // Apply pagination
+    const offset = options.offset ?? 0;
+    let paginatedDocuments;
+    if (limit > 0) {
+      paginatedDocuments = documents.slice(offset, offset + limit);
+    } else {
+      paginatedDocuments = documents.slice(offset);
+    }
+
+    // Add identities
+    await identitiesService.addCreatedByAndModifiedByIdentitiesToAll(paginatedDocuments);
+
+    // Prepare the return value
+    if (options.includePagination) {
+      const returnValue = {
+        pagination: {
+          total: documents.length,
+          offset: options.offset,
+          limit: options.limit,
+        },
+        data: paginatedDocuments,
+      };
+      return returnValue;
+    } else {
+      return paginatedDocuments;
     }
   }
+}
 
-  // Apply pagination
-  const offset = options.offset ?? 0;
-  let paginatedDocuments;
-  if (limit > 0) {
-    paginatedDocuments = documents.slice(offset, offset + limit);
-  } else {
-    paginatedDocuments = documents.slice(offset);
-  }
-
-  // Add identities
-  await identitiesService.addCreatedByAndModifiedByIdentitiesToAll(paginatedDocuments);
-
-  // Prepare the return value
-  if (options.includePagination) {
-    const returnValue = {
-      pagination: {
-        total: documents.length,
-        offset: options.offset,
-        limit: options.limit,
-      },
-      data: paginatedDocuments,
-    };
-    return returnValue;
-  } else {
-    return paginatedDocuments;
-  }
-};
+module.exports = new RecentActivityService(recentActivityRepository);

--- a/app/services/recent-activity-service.js
+++ b/app/services/recent-activity-service.js
@@ -38,8 +38,8 @@ class RecentActivityService {
     // Apply pagination
     const offset = options.offset ?? 0;
     let paginatedDocuments;
-    if (limit > 0) {
-      paginatedDocuments = documents.slice(offset, offset + limit);
+    if (options.limit > 0) {
+      paginatedDocuments = documents.slice(offset, offset + options.limit);
     } else {
       paginatedDocuments = documents.slice(offset);
     }

--- a/app/services/recent-activity-service.js
+++ b/app/services/recent-activity-service.js
@@ -4,7 +4,6 @@ const recentActivityRepository = require('../repository/recent-activity-reposito
 const identitiesService = require('./identities-service');
 
 class RecentActivityService {
-
   constructor(repository) {
     this.repository = repository;
   }


### PR DESCRIPTION
Admittedly, I don't love the `RecentActivityRepository` implementation.

Concerns:

* It doesn't exactly follow the mold/standard convention of the other services. For one, it is not extending `BaseRepository`
* It's essentially just a bucket for a single, edge-base  method (`retrieveAll`) that calls both the `AttackObject` and `Relationship` Mongoose models. I feel like we should be able to do this by chaining together a few calls to `attackObjectsService` and `relationshipsService`.

But I can't think of a more graceful solution at the moment, and this is still a step forward