### PR TITLE
fix: stop lazy loading services

### DIFF
--- a/app/services/tactics-service.js
+++ b/app/services/tactics-service.js
@@ -3,8 +3,8 @@
 const config = require('../config/config');
 const BaseService = require('./_base.service');
 const tacticsRepository = require('../repository/tactics-repository');
-
 const { Tactic: TacticType } = require('../lib/types');
+const techniquesService = require('./techniques-service');
 const { BadlyFormattedParameterError, MissingParameterError } = require('../exceptions');
 
 class TacticsService extends BaseService {
@@ -36,10 +36,6 @@ class TacticsService extends BaseService {
   }
 
   async retrieveTechniquesForTactic(stixId, modified, options) {
-    // Late binding to avoid circular dependency between modules
-    if (!TacticsService.techniquesService) {
-      TacticsService.techniquesService = require('./techniques-service');
-    }
 
     // Retrieve the techniques associated with the tactic (the tactic identified by stixId and modified date)
     if (!stixId) {
@@ -57,7 +53,7 @@ class TacticsService extends BaseService {
       if (!tactic) {
         return null;
       } else {
-        const allTechniques = await TacticsService.techniquesService.retrieveAll({});
+        const allTechniques = await techniquesService.retrieveAll({});
         const filteredTechniques = allTechniques.filter(
           TacticsService.techniqueMatchesTactic(tactic),
         );


### PR DESCRIPTION
Closes #378 

- The matrix service was lazy loading the tactics service
- Consequently, the tactics service was lazy loading the techniques service
- This is an artifact of the previous implementation (pre project-orion) and is no longer necessary
- Just load the services at the module scope and call the methods asynchronously

Tested the changes in a local development environment