### PR TITLE
382 bug stix bundle export

### DIFF
--- a/app/services/stix-bundles-service.js
+++ b/app/services/stix-bundles-service.js
@@ -180,7 +180,25 @@ class StixBundlesService extends BaseService {
     const stixOptionalArrayProperties = [
       'x_mitre_aliases',
       'x_mitre_contributors',
-      // ... other properties as in original
+      'x_mitre_data_sources',
+      'x_mitre_defense_bypassed',
+      'x_mitre_domains',
+      'x_mitre_effective_permissions',
+      'x_mitre_impact_type',
+      'x_mitre_related_assets',
+      'x_mitre_sectors',
+      'x_mitre_system_requirements',
+      'x_mitre_permissions_required',
+      'x_mitre_platforms',
+      'x_mitre_remote_support',
+      'x_mitre_tactic_type',
+      'external_references',
+      'kill_chain_phases',
+      'aliases',
+      'labels',
+      'object_marking_refs',
+      'roles',
+      'sectors',
     ];
 
     if (stixVersion === '2.0') {

--- a/app/services/stix-bundles-service.js
+++ b/app/services/stix-bundles-service.js
@@ -537,7 +537,9 @@ class StixBundlesService extends BaseService {
     }
 
     // Convert LinkById tags to markdown citations
-    await this.convertLinkedById(bundle.objects);
+    for (const bundleObject of bundle.objects) {
+      await linkById.convertLinkByIdTags(bundleObject);
+    }
 
     // Process identities and marking definitions
     await this.processIdentitiesAndMarkings(bundle);
@@ -926,16 +928,6 @@ class StixBundlesService extends BaseService {
     } catch (err) {
       logger.error(`Error retrieving attack object ${stixId}:`, err);
       return null;
-    }
-  }
-
-  /**
-   * Converts LinkById tags to markdown citations
-   * @param {Array<Object>} bundleObjects - Objects in the bundle
-   */
-  async convertLinkedById(bundleObjects) {
-    for (const bundleObject of bundleObjects) {
-      await linkById.convertLinkByIdTags(bundleObject, this.getAttackObject);
     }
   }
 }

--- a/app/services/stix-bundles-service.js
+++ b/app/services/stix-bundles-service.js
@@ -545,9 +545,7 @@ class StixBundlesService extends BaseService {
     }
 
     // Convert LinkById tags to markdown citations
-    for (const bundleObject of bundle.objects) {
-      await linkById.convertLinkByIdTags(bundleObject, this.getAttackObjectFromMap);
-    }
+    await this.convertLinkByIdTags(bundle.objects, this.attackObjectByAttackIdCache);
 
     // Process identities and marking definitions
     await this.processIdentitiesAndMarkings(bundle);
@@ -947,11 +945,22 @@ class StixBundlesService extends BaseService {
     }
   }
 
-  async getAttackObjectFromMap(attackId) {
-    return (
-      this.attackObjectByAttackIdCache.get(attackId) ||
-      (await linkById.getAttackObjectFromDatabase(attackId))
-    );
+  /**
+   * Converts LinkById tags to markdown citations
+   * @param {Array<Object>} bundleObjects - Objects in the bundle
+   * @param {Map} attackObjectByAttackIdCache - Map of attack objects
+   */
+  async convertLinkByIdTags(bundleObjects, attackObjectByAttackIdCache) {
+    const getAttackObjectFromMap = async function (attackId) {
+      return (
+        attackObjectByAttackIdCache.get(attackId) ||
+        (await linkById.getAttackObjectFromDatabase(attackId))
+      );
+    };
+
+    for (const bundleObject of bundleObjects) {
+      await linkById.convertLinkByIdTags(bundleObject, getAttackObjectFromMap);
+    }
   }
 }
 


### PR DESCRIPTION
This fixes two regressions in project-orion:
- LinkById resolution during STIX bundle export
- Remove empty arrays