### PR TITLE
STIX cleanup

### DIFF
--- a/app/api/definitions/components/identities.yml
+++ b/app/api/definitions/components/identities.yml
@@ -39,9 +39,6 @@ components:
             contact_information:
               type: string
             # ATT&CK custom properties
-            x_mitre_deprecated:
-              type: boolean
-              example: false
             x_mitre_attack_spec_version:
               type: string
               example: '2.1.0'

--- a/app/api/definitions/components/identities.yml
+++ b/app/api/definitions/components/identities.yml
@@ -39,9 +39,6 @@ components:
             contact_information:
               type: string
             # ATT&CK custom properties
-            x_mitre_modified_by_ref:
-              type: string
-              example: 'identity--6444f546-6900-4456-b3b1-015c88d70dab'
             x_mitre_deprecated:
               type: boolean
               example: false

--- a/app/api/definitions/components/identities.yml
+++ b/app/api/definitions/components/identities.yml
@@ -45,9 +45,6 @@ components:
             x_mitre_deprecated:
               type: boolean
               example: false
-            x_mitre_version:
-              type: string
-              example: '1.0'
             x_mitre_attack_spec_version:
               type: string
               example: '2.1.0'

--- a/app/api/definitions/components/marking-definitions.yml
+++ b/app/api/definitions/components/marking-definitions.yml
@@ -28,9 +28,6 @@ components:
             x_mitre_deprecated:
               type: boolean
               example: false
-            x_mitre_attack_spec_version:
-              type: string
-              example: '2.1.0'
 
     marking-object-definition:
       type: object

--- a/app/api/definitions/components/marking-definitions.yml
+++ b/app/api/definitions/components/marking-definitions.yml
@@ -24,10 +24,6 @@ components:
               example: 'statement'
             definition:
               $ref: '#/components/schemas/marking-object-definition'
-            # ATT&CK custom properties
-            x_mitre_deprecated:
-              type: boolean
-              example: false
 
     marking-object-definition:
       type: object

--- a/app/api/definitions/components/relationships.yml
+++ b/app/api/definitions/components/relationships.yml
@@ -44,10 +44,6 @@ components:
             x_mitre_deprecated:
               type: boolean
               example: false
-            x_mitre_domains:
-              type: array
-              items:
-                type: string
             x_mitre_attack_spec_version:
               type: string
               example: '2.1.0'

--- a/app/api/definitions/components/relationships.yml
+++ b/app/api/definitions/components/relationships.yml
@@ -48,9 +48,6 @@ components:
               type: array
               items:
                 type: string
-            x_mitre_version:
-              type: string
-              example: '1.0'
             x_mitre_attack_spec_version:
               type: string
               example: '2.1.0'

--- a/app/models/asset-model.js
+++ b/app/models/asset-model.js
@@ -23,7 +23,7 @@ const stixAsset = {
   x_mitre_related_assets: [relatedAssetSchema],
   x_mitre_modified_by_ref: String,
   x_mitre_platforms: [String],
-  x_mitre_deprecated: Boolean,
+  x_mitre_deprecated: { type: Boolean, required: true, default: false },
   x_mitre_domains: [String],
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,

--- a/app/models/asset-model.js
+++ b/app/models/asset-model.js
@@ -24,7 +24,7 @@ const stixAsset = {
   x_mitre_modified_by_ref: String,
   x_mitre_platforms: [String],
   x_mitre_deprecated: { type: Boolean, required: true, default: false },
-  x_mitre_domains: [String],
+  x_mitre_domains: { type: [String], default: undefined },
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,
   x_mitre_contributors: [String],

--- a/app/models/campaign-model.js
+++ b/app/models/campaign-model.js
@@ -18,7 +18,7 @@ const stixCampaign = {
   x_mitre_first_seen_citation: { type: String, required: true },
   x_mitre_last_seen_citation: { type: String, required: true },
   x_mitre_modified_by_ref: String,
-  x_mitre_deprecated: Boolean,
+  x_mitre_deprecated: { type: Boolean, required: true, default: false },
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,
   x_mitre_contributors: [String],

--- a/app/models/collection-model.js
+++ b/app/models/collection-model.js
@@ -20,7 +20,7 @@ const xMitreCollection = {
   x_mitre_modified_by_ref: String,
   x_mitre_contents: [xMitreContentSchema],
   x_mitre_deprecated: { type: Boolean, required: true, default: false },
-  x_mitre_domains: [String],
+  x_mitre_domains: { type: [String], default: undefined },
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,
 };

--- a/app/models/collection-model.js
+++ b/app/models/collection-model.js
@@ -19,7 +19,7 @@ const xMitreCollection = {
 
   x_mitre_modified_by_ref: String,
   x_mitre_contents: [xMitreContentSchema],
-  x_mitre_deprecated: Boolean,
+  x_mitre_deprecated: { type: Boolean, required: true, default: false },
   x_mitre_domains: [String],
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,

--- a/app/models/data-component-model.js
+++ b/app/models/data-component-model.js
@@ -15,7 +15,7 @@ const stixDataComponent = {
   x_mitre_data_source_ref: String,
   x_mitre_modified_by_ref: String,
   x_mitre_deprecated: { type: Boolean, required: true, default: false },
-  x_mitre_domains: [String],
+  x_mitre_domains: { type: [String], default: undefined },
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,
 };

--- a/app/models/data-component-model.js
+++ b/app/models/data-component-model.js
@@ -14,7 +14,7 @@ const stixDataComponent = {
   // ATT&CK custom stix properties
   x_mitre_data_source_ref: String,
   x_mitre_modified_by_ref: String,
-  x_mitre_deprecated: Boolean,
+  x_mitre_deprecated: { type: Boolean, required: true, default: false },
   x_mitre_domains: [String],
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,

--- a/app/models/data-source-model.js
+++ b/app/models/data-source-model.js
@@ -15,7 +15,7 @@ const stixDataSource = {
   x_mitre_modified_by_ref: String,
   x_mitre_platforms: [String],
   x_mitre_deprecated: { type: Boolean, required: true, default: false },
-  x_mitre_domains: [String],
+  x_mitre_domains: { type: [String], default: undefined },
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,
   x_mitre_contributors: [String],

--- a/app/models/data-source-model.js
+++ b/app/models/data-source-model.js
@@ -14,7 +14,7 @@ const stixDataSource = {
   // ATT&CK custom stix properties
   x_mitre_modified_by_ref: String,
   x_mitre_platforms: [String],
-  x_mitre_deprecated: Boolean,
+  x_mitre_deprecated: { type: Boolean, required: true, default: false },
   x_mitre_domains: [String],
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,

--- a/app/models/group-model.js
+++ b/app/models/group-model.js
@@ -14,7 +14,7 @@ const stixIntrusionSet = {
   // ATT&CK custom stix properties
   aliases: [String],
   x_mitre_modified_by_ref: String,
-  x_mitre_deprecated: Boolean,
+  x_mitre_deprecated: { type: Boolean, required: true, default: false },
   x_mitre_domains: [String], // TBD drop this property
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,

--- a/app/models/group-model.js
+++ b/app/models/group-model.js
@@ -15,7 +15,7 @@ const stixIntrusionSet = {
   aliases: [String],
   x_mitre_modified_by_ref: String,
   x_mitre_deprecated: { type: Boolean, required: true, default: false },
-  x_mitre_domains: [String], // TBD drop this property
+  x_mitre_domains: { type: [String], default: undefined }, // TBD drop this property
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,
   x_mitre_contributors: [String],

--- a/app/models/identity-model.js
+++ b/app/models/identity-model.js
@@ -18,7 +18,6 @@ const identityProperties = {
   // ATT&CK custom stix properties
   x_mitre_modified_by_ref: String,
   x_mitre_deprecated: Boolean,
-  x_mitre_version: String,
   x_mitre_attack_spec_version: String,
 };
 

--- a/app/models/identity-model.js
+++ b/app/models/identity-model.js
@@ -16,7 +16,6 @@ const identityProperties = {
   contact_information: String,
 
   // ATT&CK custom stix properties
-  x_mitre_deprecated: Boolean,
   x_mitre_attack_spec_version: String,
 };
 

--- a/app/models/identity-model.js
+++ b/app/models/identity-model.js
@@ -16,7 +16,6 @@ const identityProperties = {
   contact_information: String,
 
   // ATT&CK custom stix properties
-  x_mitre_modified_by_ref: String,
   x_mitre_deprecated: Boolean,
   x_mitre_attack_spec_version: String,
 };

--- a/app/models/marking-definition-model.js
+++ b/app/models/marking-definition-model.js
@@ -17,9 +17,6 @@ const markingDefinitionProperties = {
   name: String,
   definition_type: String,
   definition: markingObject,
-
-  // ATT&CK custom stix properties
-  x_mitre_deprecated: Boolean,
 };
 
 // Create the definition

--- a/app/models/marking-definition-model.js
+++ b/app/models/marking-definition-model.js
@@ -20,7 +20,6 @@ const markingDefinitionProperties = {
 
   // ATT&CK custom stix properties
   x_mitre_deprecated: Boolean,
-  x_mitre_attack_spec_version: String,
 };
 
 // Create the definition

--- a/app/models/matrix-model.js
+++ b/app/models/matrix-model.js
@@ -15,7 +15,7 @@ const matrixProperties = {
   tactic_refs: [String],
   x_mitre_modified_by_ref: String,
   x_mitre_deprecated: { type: Boolean, required: true, default: false },
-  x_mitre_domains: [String], // TBD drop this property
+  x_mitre_domains: { type: [String], default: undefined }, // TBD drop this property
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,
 };

--- a/app/models/matrix-model.js
+++ b/app/models/matrix-model.js
@@ -14,7 +14,7 @@ const matrixProperties = {
   // ATT&CK custom stix properties
   tactic_refs: [String],
   x_mitre_modified_by_ref: String,
-  x_mitre_deprecated: Boolean,
+  x_mitre_deprecated: { type: Boolean, required: true, default: false },
   x_mitre_domains: [String], // TBD drop this property
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,

--- a/app/models/mitigation-model.js
+++ b/app/models/mitigation-model.js
@@ -14,7 +14,7 @@ const stixCourseOfAction = {
 
   // ATT&CK custom stix properties
   x_mitre_modified_by_ref: String,
-  x_mitre_deprecated: Boolean,
+  x_mitre_deprecated: { type: Boolean, required: true, default: false },
   x_mitre_domains: [String],
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,

--- a/app/models/mitigation-model.js
+++ b/app/models/mitigation-model.js
@@ -10,7 +10,7 @@ const stixCourseOfAction = {
   modified: { type: Date, required: true },
   name: { type: String, required: true },
   description: String,
-  labels: [String],
+  labels: { type: [String], default: undefined },
 
   // ATT&CK custom stix properties
   x_mitre_modified_by_ref: String,

--- a/app/models/mitigation-model.js
+++ b/app/models/mitigation-model.js
@@ -15,7 +15,7 @@ const stixCourseOfAction = {
   // ATT&CK custom stix properties
   x_mitre_modified_by_ref: String,
   x_mitre_deprecated: { type: Boolean, required: true, default: false },
-  x_mitre_domains: [String],
+  x_mitre_domains: { type: [String], default: undefined },
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,
 };

--- a/app/models/note-model.js
+++ b/app/models/note-model.js
@@ -15,7 +15,7 @@ const noteProperties = {
 
   // ATT&CK custom stix properties
   x_mitre_modified_by_ref: String,
-  x_mitre_deprecated: Boolean,
+  x_mitre_deprecated: { type: Boolean, required: true, default: false },
   x_mitre_attack_spec_version: String,
 };
 

--- a/app/models/relationship-model.js
+++ b/app/models/relationship-model.js
@@ -19,7 +19,6 @@ const relationshipProperties = {
   // ATT&CK custom stix properties
   x_mitre_modified_by_ref: String,
   x_mitre_deprecated: Boolean,
-  x_mitre_version: String,
   x_mitre_attack_spec_version: String,
 };
 

--- a/app/models/software-model.js
+++ b/app/models/software-model.js
@@ -11,7 +11,6 @@ const stixMalware = {
   name: { type: String, required: true },
   description: String,
   is_family: Boolean,
-  labels: [String],
 
   // ATT&CK custom stix properties
   x_mitre_modified_by_ref: String,

--- a/app/models/software-model.js
+++ b/app/models/software-model.js
@@ -16,7 +16,7 @@ const stixMalware = {
   x_mitre_modified_by_ref: String,
   x_mitre_platforms: [String],
   x_mitre_deprecated: { type: Boolean, required: true, default: false },
-  x_mitre_domains: [String],
+  x_mitre_domains: { type: [String], default: undefined },
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,
   x_mitre_contributors: [String],

--- a/app/models/software-model.js
+++ b/app/models/software-model.js
@@ -15,7 +15,7 @@ const stixMalware = {
   // ATT&CK custom stix properties
   x_mitre_modified_by_ref: String,
   x_mitre_platforms: [String],
-  x_mitre_deprecated: Boolean,
+  x_mitre_deprecated: { type: Boolean, required: true, default: false },
   x_mitre_domains: [String],
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,

--- a/app/models/subschemas/attack-pattern.js
+++ b/app/models/subschemas/attack-pattern.js
@@ -15,7 +15,7 @@ module.exports.attackPattern = {
   x_mitre_deprecated: { type: Boolean, required: true, default: false },
   x_mitre_detection: String,
   x_mitre_domains: { type: [String], default: undefined },
-  x_mitre_is_subtechnique: Boolean,
+  x_mitre_is_subtechnique: { type: Boolean, required: true, default: false },
   x_mitre_modified_by_ref: String,
   x_mitre_platforms: [String],
   x_mitre_version: String,

--- a/app/models/subschemas/attack-pattern.js
+++ b/app/models/subschemas/attack-pattern.js
@@ -12,7 +12,7 @@ module.exports.attackPattern = {
   // ATT&CK custom STIX properties
   x_mitre_attack_spec_version: String,
   x_mitre_contributors: [String],
-  x_mitre_deprecated: Boolean,
+  x_mitre_deprecated: { type: Boolean, required: true, default: false },
   x_mitre_detection: String,
   x_mitre_domains: [String],
   x_mitre_is_subtechnique: Boolean,

--- a/app/models/subschemas/attack-pattern.js
+++ b/app/models/subschemas/attack-pattern.js
@@ -14,7 +14,7 @@ module.exports.attackPattern = {
   x_mitre_contributors: [String],
   x_mitre_deprecated: { type: Boolean, required: true, default: false },
   x_mitre_detection: String,
-  x_mitre_domains: [String],
+  x_mitre_domains: { type: [String], default: undefined },
   x_mitre_is_subtechnique: Boolean,
   x_mitre_modified_by_ref: String,
   x_mitre_platforms: [String],

--- a/app/models/tactic-model.js
+++ b/app/models/tactic-model.js
@@ -13,7 +13,7 @@ const stixTactic = {
 
   // ATT&CK custom stix properties
   x_mitre_modified_by_ref: String,
-  x_mitre_deprecated: Boolean,
+  x_mitre_deprecated: { type: Boolean, required: true, default: false },
   x_mitre_domains: [String],
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,

--- a/app/models/tactic-model.js
+++ b/app/models/tactic-model.js
@@ -14,7 +14,7 @@ const stixTactic = {
   // ATT&CK custom stix properties
   x_mitre_modified_by_ref: String,
   x_mitre_deprecated: { type: Boolean, required: true, default: false },
-  x_mitre_domains: [String],
+  x_mitre_domains: { type: [String], default: undefined },
   x_mitre_version: String,
   x_mitre_attack_spec_version: String,
   x_mitre_contributors: [String],

--- a/app/services/collection-bundles-service/export-bundle.js
+++ b/app/services/collection-bundles-service/export-bundle.js
@@ -99,8 +99,8 @@ async function addDerivedDataSources(bundleObjects) {
   // Process techniques
   for (const bundleObject of bundleObjects) {
     if (bundleObject.type === 'attack-pattern') {
-      const enterpriseDomain = bundleObject.x_mitre_domains.includes('enterprise-attack');
-      const icsDomain = bundleObject.x_mitre_domains.includes('ics-attack');
+      const enterpriseDomain = bundleObject.x_mitre_domains?.includes('enterprise-attack');
+      const icsDomain = bundleObject.x_mitre_domains?.includes('ics-attack');
 
       processTechniqueDataSources(
         bundleObject,

--- a/app/services/collection-bundles-service/import-bundle.js
+++ b/app/services/collection-bundles-service/import-bundle.js
@@ -287,29 +287,32 @@ async function processObjects(
       importedCollection.workspace.import_categories.errors.push(importError);
     }
 
-    // Check ATT&CK Spec Version compatibility
-    const objectAttackSpecVersion =
-      importObject.x_mitre_attack_spec_version ?? defaultAttackSpecVersion;
-    if (semver.gt(objectAttackSpecVersion, config.app.attackSpecVersion)) {
-      const importError = {
-        object_ref: importObject.id,
-        object_modified: importObject.modified,
-        error_type: importErrors.attackSpecVersionViolation,
-        error_message: 'Error: Object x_mitre_attack_spec_version later than system.',
-      };
-      logger.verbose(
-        `Import Bundle Error: Object's x_mitre_attack_spec_version later than system. id=${importObject.id}, modified=${importObject.modified}`,
-      );
-      importedCollection.workspace.import_categories.errors.push(importError);
+    if (importObject.type != 'marking-definition') {
+      // Check ATT&CK Spec Version compatibility
+      const objectAttackSpecVersion =
+        importObject.x_mitre_attack_spec_version ?? defaultAttackSpecVersion;
+      if (semver.gt(objectAttackSpecVersion, config.app.attackSpecVersion)) {
+        const importError = {
+          object_ref: importObject.id,
+          object_modified: importObject.modified,
+          error_type: importErrors.attackSpecVersionViolation,
+          error_message: 'Error: Object x_mitre_attack_spec_version later than system.',
+        };
+        logger.verbose(
+          `Import Bundle Error: Object's x_mitre_attack_spec_version later than system. id=${importObject.id}, modified=${importObject.modified}`,
+        );
+        importedCollection.workspace.import_categories.errors.push(importError);
 
-      if (
-        !options.forceImportParameters?.includes(forceImportParameters.attackSpecVersionViolations)
-      ) {
-        throw new Error(errors.attackSpecVersionViolation);
+        if (
+          !options.forceImportParameters?.includes(
+            forceImportParameters.attackSpecVersionViolations,
+          )
+        ) {
+          throw new Error(errors.attackSpecVersionViolation);
+        }
+        continue;
       }
-      continue;
     }
-
     await processStixObject(
       importObject,
       options,

--- a/app/services/collection-bundles-service/validate-bundle.js
+++ b/app/services/collection-bundles-service/validate-bundle.js
@@ -42,24 +42,25 @@ module.exports = function validateBundle(bundle) {
         objectMap.set(key, stixObject);
       }
 
-      // Validate ATT&CK spec version compatibility
-      const objectAttackSpecVersion =
-        stixObject.x_mitre_attack_spec_version ?? defaultAttackSpecVersion;
+      if (stixObject.type != 'marking-definition') {
+        // Validate ATT&CK spec version compatibility
+        const objectAttackSpecVersion =
+          stixObject.x_mitre_attack_spec_version ?? defaultAttackSpecVersion;
 
-      // Check if version is valid semver and compatible with system version
-      if (
-        !semver.valid(objectAttackSpecVersion) ||
-        semver.gt(objectAttackSpecVersion, config.app.attackSpecVersion)
-      ) {
-        validationResult.errors.push({
-          type: validationErrors.invalidAttackSpecVersion,
-          id: stixObject.id,
-          modified: stixObject.modified,
-        });
-        validationResult.invalidAttackSpecVersionCount += 1;
+        // Check if version is valid semver and compatible with system version
+        if (
+          !semver.valid(objectAttackSpecVersion) ||
+          semver.gt(objectAttackSpecVersion, config.app.attackSpecVersion)
+        ) {
+          validationResult.errors.push({
+            type: validationErrors.invalidAttackSpecVersion,
+            id: stixObject.id,
+            modified: stixObject.modified,
+          });
+          validationResult.invalidAttackSpecVersionCount += 1;
+        }
       }
     }
-
     return validationResult;
   } catch (error) {
     throw new Error(`Bundle validation failed: ${error.message}`);

--- a/app/services/marking-definitions-service.js
+++ b/app/services/marking-definitions-service.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const uuid = require('uuid');
-const config = require('../config/config');
 const BaseService = require('./_base.service');
 const markingDefinitionsRepository = require('../repository/marking-definitions-repository');
 const { MarkingDefinition: MarkingDefinitionType } = require('../lib/types');
@@ -28,10 +27,6 @@ class MarkingDefinitionsService extends BaseService {
 
     options = options || {};
     if (!options.import) {
-      // Set the ATT&CK Spec Version
-      markingDefinition.stix.x_mitre_attack_spec_version =
-        markingDefinition.stix.x_mitre_attack_spec_version ?? config.app.attackSpecVersion;
-
       // Record the user account that created the object
       if (options.userAccountId) {
         markingDefinition.workspace.workflow.created_by_user_account = options.userAccountId;

--- a/app/services/stix-bundles-service.js
+++ b/app/services/stix-bundles-service.js
@@ -336,6 +336,7 @@ class StixBundlesService extends BaseService {
   static processDataComponents(bundle, techniqueDetectedBy, dataComponents, dataSources) {
     for (const bundleObject of bundle.objects) {
       if (bundleObject.type === 'attack-pattern') {
+        // TODO remove this line once all techniques are confirmed to have x_mitre_is_subtechnique
         bundleObject.x_mitre_is_subtechnique = bundleObject.x_mitre_is_subtechnique ?? false;
 
         const enterpriseDomain = bundleObject.x_mitre_domains?.includes('enterprise-attack');

--- a/app/services/stix-bundles-service.js
+++ b/app/services/stix-bundles-service.js
@@ -256,7 +256,9 @@ class StixBundlesService extends BaseService {
 
     // Handle domains for groups and campaigns
     if (secondaryObject.stix.type === 'intrusion-set' || secondaryObject.stix.type === 'campaign') {
-      this.domainCache.set(secondaryObject.stix.id, secondaryObject.stix.x_mitre_domains);
+      if (secondaryObject.stix.x_mitre_domains) {
+        this.domainCache.set(secondaryObject.stix.id, secondaryObject.stix.x_mitre_domains);
+      }
       secondaryObject.stix.x_mitre_domains =
         await this.getDomainsForSecondaryObject(secondaryObject);
     }
@@ -336,8 +338,8 @@ class StixBundlesService extends BaseService {
       if (bundleObject.type === 'attack-pattern') {
         bundleObject.x_mitre_is_subtechnique = bundleObject.x_mitre_is_subtechnique ?? false;
 
-        const enterpriseDomain = bundleObject.x_mitre_domains.includes('enterprise-attack');
-        const icsDomain = bundleObject.x_mitre_domains.includes('ics-attack');
+        const enterpriseDomain = bundleObject.x_mitre_domains?.includes('enterprise-attack');
+        const icsDomain = bundleObject.x_mitre_domains?.includes('ics-attack');
 
         if (enterpriseDomain || icsDomain) {
           StixBundlesService.addDerivedDataSources(
@@ -696,7 +698,9 @@ class StixBundlesService extends BaseService {
           groupObject.stix.type === 'intrusion-set' &&
           StixBundlesService.secondaryObjectIsValid(groupObject, options)
         ) {
-          this.domainCache.set(groupObject.stix.id, groupObject.stix.x_mitre_domains);
+          if (groupObject.stix.x_mitre_domains) {
+            this.domainCache.set(groupObject.stix.id, groupObject.stix.x_mitre_domains);
+          }
           groupObject.stix.x_mitre_domains = [options.domain];
           this.addAttackObjectToBundle(groupObject, bundle, objectsMap);
         }
@@ -714,7 +718,9 @@ class StixBundlesService extends BaseService {
             revokedObject.stix.type === 'intrusion-set' ||
             revokedObject.stix.type === 'campaign'
           ) {
-            this.domainCache.set(revokedObject.stix.id, revokedObject.stix.x_mitre_domains);
+            if (revokedObject.stix.x_mitre_domains) {
+              this.domainCache.set(revokedObject.stix.id, revokedObject.stix.x_mitre_domains);
+            }
             revokedObject.stix.x_mitre_domains = [options.domain];
           }
           this.addAttackObjectToBundle(revokedObject, bundle, objectsMap);

--- a/app/tests/api/attack-objects/attack-objects-1.json
+++ b/app/tests/api/attack-objects/attack-objects-1.json
@@ -483,7 +483,6 @@
       "created": "2020-01-01T00:00:00.000Z",
       "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
       "definition_type": "statement",
-      "x_mitre_attack_spec_version": "2.1.0",
       "spec_version": "2.1",
       "x_mitre_domains": ["ics-attack"]
     }

--- a/app/tests/api/attack-objects/attack-objects-1.json
+++ b/app/tests/api/attack-objects/attack-objects-1.json
@@ -471,8 +471,7 @@
       "modified": "2017-06-01T00:00:00.000Z",
       "name": "The Corporate Entity",
       "spec_version": "2.1",
-      "x_mitre_attack_spec_version": "2.1.0",
-      "x_mitre_version": "1.0"
+      "x_mitre_attack_spec_version": "2.1.0"
     },
     {
       "definition": {

--- a/app/tests/api/attack-objects/attack-objects-2.json
+++ b/app/tests/api/attack-objects/attack-objects-2.json
@@ -73,8 +73,7 @@
       "modified": "2017-06-01T00:00:00.000Z",
       "name": "The Corporate Entity",
       "spec_version": "2.1",
-      "x_mitre_attack_spec_version": "2.1.0",
-      "x_mitre_version": "1.0"
+      "x_mitre_attack_spec_version": "2.1.0"
     },
     {
       "definition": {

--- a/app/tests/api/attack-objects/attack-objects-2.json
+++ b/app/tests/api/attack-objects/attack-objects-2.json
@@ -85,7 +85,6 @@
       "created": "2020-01-01T00:00:00.000Z",
       "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
       "definition_type": "statement",
-      "x_mitre_attack_spec_version": "2.1.0",
       "spec_version": "2.1",
       "x_mitre_domains": ["ics-attack"]
     }

--- a/app/tests/api/marking-definitions/marking-definitions.spec.js
+++ b/app/tests/api/marking-definitions/marking-definitions.spec.js
@@ -4,7 +4,6 @@ const { expect } = require('expect');
 const database = require('../../../lib/database-in-memory');
 const databaseConfiguration = require('../../../lib/database-configuration');
 
-const config = require('../../../config/config');
 const login = require('../../shared/login');
 
 const logger = require('../../../lib/logger');
@@ -90,8 +89,6 @@ describe('Marking Definitions API', function () {
     expect(markingDefinition1.stix).toBeDefined();
     expect(markingDefinition1.stix.id).toBeDefined();
     expect(markingDefinition1.stix.created).toBeDefined();
-    // stix.modified does not exist for marking definitions
-    expect(markingDefinition1.stix.x_mitre_attack_spec_version).toBe(config.app.attackSpecVersion);
   });
 
   it('GET /api/marking-definitions returns the added marking definition', async function () {
@@ -147,9 +144,6 @@ describe('Marking Definitions API', function () {
       expect.arrayContaining(markingDefinition1.stix.object_marking_refs),
     );
     expect(markingDefinition.stix.created_by_ref).toBe(markingDefinition1.stix.created_by_ref);
-    expect(markingDefinition.stix.x_mitre_attack_spec_version).toBe(
-      markingDefinition1.stix.x_mitre_attack_spec_version,
-    );
   });
 
   it('PUT /api/marking-definitions updates a marking definition', async function () {

--- a/app/tests/api/matrices/matrices.techniques.tactics.json
+++ b/app/tests/api/matrices/matrices.techniques.tactics.json
@@ -324,7 +324,6 @@
       "created": "2020-01-01T00:00:00.000Z",
       "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
       "definition_type": "statement",
-      "x_mitre_attack_spec_version": "2.1.0",
       "spec_version": "2.1",
       "x_mitre_domains": ["ics-attack"]
     }

--- a/app/tests/api/matrices/matrices.techniques.tactics.json
+++ b/app/tests/api/matrices/matrices.techniques.tactics.json
@@ -312,8 +312,7 @@
       "name": "The MITRE Corporation",
       "spec_version": "2.1",
       "x_mitre_attack_spec_version": "2.1.0",
-      "x_mitre_domains": ["ics-attack"],
-      "x_mitre_version": "1.0"
+      "x_mitre_domains": ["ics-attack"]
     },
     {
       "definition": {

--- a/app/tests/api/recent-activity/sample-collection.json
+++ b/app/tests/api/recent-activity/sample-collection.json
@@ -324,7 +324,6 @@
       "created": "2020-01-01T00:00:00.000Z",
       "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
       "definition_type": "statement",
-      "x_mitre_attack_spec_version": "2.1.0",
       "spec_version": "2.1",
       "x_mitre_domains": ["ics-attack"]
     }

--- a/app/tests/api/recent-activity/sample-collection.json
+++ b/app/tests/api/recent-activity/sample-collection.json
@@ -312,8 +312,7 @@
       "name": "The MITRE Corporation",
       "spec_version": "2.1",
       "x_mitre_attack_spec_version": "2.1.0",
-      "x_mitre_domains": ["ics-attack"],
-      "x_mitre_version": "1.0"
+      "x_mitre_domains": ["ics-attack"]
     },
     {
       "definition": {

--- a/app/tests/api/tactics/tactics.spec.js
+++ b/app/tests/api/tactics/tactics.spec.js
@@ -152,7 +152,7 @@ describe('Tactics API', function () {
     expect(tactic.stix.x_mitre_modified_by_ref).toBe(tactic1.stix.x_mitre_modified_by_ref);
     expect(tactic.stix.x_mitre_attack_spec_version).toBe(tactic1.stix.x_mitre_attack_spec_version);
 
-    expect(tactic.stix.x_mitre_deprecated).not.toBeDefined();
+    expect(tactic.stix.x_mitre_deprecated).toBe(false);
   });
 
   it('PUT /api/tactics updates a tactic', async function () {

--- a/app/tests/api/tactics/tactics.techniques.json
+++ b/app/tests/api/tactics/tactics.techniques.json
@@ -379,8 +379,7 @@
       "modified": "2017-06-01T00:00:00.000Z",
       "name": "The Corporate Entity",
       "spec_version": "2.1",
-      "x_mitre_attack_spec_version": "2.1.0",
-      "x_mitre_version": "1.0"
+      "x_mitre_attack_spec_version": "2.1.0"
     },
     {
       "definition": {

--- a/app/tests/api/tactics/tactics.techniques.json
+++ b/app/tests/api/tactics/tactics.techniques.json
@@ -391,7 +391,6 @@
       "created": "2020-01-01T00:00:00.000Z",
       "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
       "definition_type": "statement",
-      "x_mitre_attack_spec_version": "2.1.0",
       "spec_version": "2.1",
       "x_mitre_domains": ["ics-attack"]
     }

--- a/app/tests/api/techniques/techniques.spec.js
+++ b/app/tests/api/techniques/techniques.spec.js
@@ -185,7 +185,7 @@ describe('Techniques Basic API', function () {
 
     expect(technique.workspace.attack_id).toEqual(technique1.workspace.attack_id);
 
-    expect(technique.stix.x_mitre_deprecated).not.toBeDefined();
+    expect(technique.stix.x_mitre_deprecated).toBe(false);
     expect(technique.stix.x_mitre_defense_bypassed).not.toBeDefined();
     expect(technique.stix.x_mitre_permissions_required).not.toBeDefined();
     expect(technique.stix.x_mitre_system_requirements).not.toBeDefined();

--- a/app/tests/api/techniques/techniques.tactics.json
+++ b/app/tests/api/techniques/techniques.tactics.json
@@ -286,8 +286,7 @@
       "name": "The MITRE Corporation",
       "spec_version": "2.1",
       "x_mitre_attack_spec_version": "2.1.0",
-      "x_mitre_domains": ["ics-attack"],
-      "x_mitre_version": "1.0"
+      "x_mitre_domains": ["ics-attack"]
     },
     {
       "definition": {

--- a/app/tests/api/techniques/techniques.tactics.json
+++ b/app/tests/api/techniques/techniques.tactics.json
@@ -298,7 +298,6 @@
       "created": "2020-01-01T00:00:00.000Z",
       "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
       "definition_type": "statement",
-      "x_mitre_attack_spec_version": "2.1.0",
       "spec_version": "2.1",
       "x_mitre_domains": ["ics-attack"]
     }

--- a/app/tests/integration-test/mock-data/blue-v1.json
+++ b/app/tests/integration-test/mock-data/blue-v1.json
@@ -86,8 +86,7 @@
       "id": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
       "created": "2017-06-01T00:00:00.000Z",
       "spec_version": "2.1",
-      "x_mitre_attack_spec_version": "2.1.0",
-      "x_mitre_version": "1.0"
+      "x_mitre_attack_spec_version": "2.1.0"
     },
     {
       "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",

--- a/app/tests/integration-test/mock-data/blue-v1.json
+++ b/app/tests/integration-test/mock-data/blue-v1.json
@@ -98,8 +98,7 @@
       "definition_type": "statement",
       "created": "2017-06-01T00:00:00Z",
       "id": "marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168",
-      "spec_version": "2.1",
-      "x_mitre_attack_spec_version": "2.1.0"
+      "spec_version": "2.1"
     }
   ]
 }

--- a/app/tests/integration-test/mock-data/blue-v2.json
+++ b/app/tests/integration-test/mock-data/blue-v2.json
@@ -124,8 +124,7 @@
       "definition_type": "statement",
       "created": "2017-06-01T00:00:00Z",
       "id": "marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168",
-      "spec_version": "2.1",
-      "x_mitre_attack_spec_version": "2.1.0"
+      "spec_version": "2.1"
     }
   ]
 }

--- a/app/tests/integration-test/mock-data/blue-v2.json
+++ b/app/tests/integration-test/mock-data/blue-v2.json
@@ -112,8 +112,7 @@
       "id": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
       "created": "2017-06-01T00:00:00.000Z",
       "spec_version": "2.1",
-      "x_mitre_attack_spec_version": "2.1.0",
-      "x_mitre_version": "1.0"
+      "x_mitre_attack_spec_version": "2.1.0"
     },
     {
       "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",

--- a/app/tests/integration-test/mock-data/green-v1.json
+++ b/app/tests/integration-test/mock-data/green-v1.json
@@ -86,8 +86,7 @@
       "id": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
       "created": "2017-06-01T00:00:00.000Z",
       "spec_version": "2.1",
-      "x_mitre_attack_spec_version": "2.1.0",
-      "x_mitre_version": "1.0"
+      "x_mitre_attack_spec_version": "2.1.0"
     },
     {
       "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",

--- a/app/tests/integration-test/mock-data/green-v1.json
+++ b/app/tests/integration-test/mock-data/green-v1.json
@@ -98,8 +98,7 @@
       "definition_type": "statement",
       "created": "2017-06-01T00:00:00Z",
       "id": "marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168",
-      "spec_version": "2.1",
-      "x_mitre_attack_spec_version": "2.1.0"
+      "spec_version": "2.1"
     }
   ]
 }

--- a/app/tests/integration-test/mock-data/red-v1.json
+++ b/app/tests/integration-test/mock-data/red-v1.json
@@ -86,8 +86,7 @@
       "id": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
       "created": "2017-06-01T00:00:00.000Z",
       "spec_version": "2.1",
-      "x_mitre_attack_spec_version": "2.1.0",
-      "x_mitre_version": "1.0"
+      "x_mitre_attack_spec_version": "2.1.0"
     },
     {
       "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",

--- a/app/tests/integration-test/mock-data/red-v1.json
+++ b/app/tests/integration-test/mock-data/red-v1.json
@@ -98,8 +98,7 @@
       "definition_type": "statement",
       "created": "2017-06-01T00:00:00Z",
       "id": "marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168",
-      "spec_version": "2.1",
-      "x_mitre_attack_spec_version": "2.1.0"
+      "spec_version": "2.1"
     }
   ]
 }


### PR DESCRIPTION
- Removed `x_mitre_attack_spec_version` from marking-definitions
- Removed `x_mitre_version` from relationships
- Removed `x_mitre_version` from identities
- Removed `x_mitre_modified_by_ref` from identities
- Removed `labels` from malware and tools
- Updated default for `labels` on mitigations to be `undefined`, vs. `[]`
- Removed `x_mitre_deprecated` from identity and SMO, made it required for others except SRO
- Updated default for `x_mitre_domains` to be `undefined`, vs. `[]`