### PR TITLE
feat: add SSE streaming support for collection endpoints with contents

### DIFF
--- a/app/api/definitions/paths/collections-paths.yml
+++ b/app/api/definitions/paths/collections-paths.yml
@@ -153,6 +153,14 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: stream
+          in: query
+          description: |
+            When used with retrieveContents=true, stream the collection contents using Server-Sent Events (SSE) instead of returning the full response.
+            This is useful for large collections to avoid memory issues and provide progress updates.
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: 'A list of collections matching the requested STIX id.'
@@ -216,6 +224,14 @@ paths:
           in: query
           description: |
             Retrieve the objects that are referenced by the collection
+          schema:
+            type: boolean
+            default: false
+        - name: stream
+          in: query
+          description: |
+            When used with retrieveContents=true, stream the collection contents using Server-Sent Events (SSE) instead of returning the full response.
+            This is useful for large collections to avoid memory issues and provide progress updates.
           schema:
             type: boolean
             default: false

--- a/app/controllers/collections-controller.js
+++ b/app/controllers/collections-controller.js
@@ -74,7 +74,7 @@ exports.retrieveVersionById = async function (req, res, next) {
     console.log('[CONTROLLER] retrieveContents param:', retrieveContents, typeof retrieveContents);
 
     const options = {
-      retrieveContents: retrieveContents === true || retrieveContents === 'true'
+      retrieveContents: retrieveContents === true || retrieveContents === 'true',
     };
 
     // Use streaming if requested and contents are being retrieved
@@ -105,7 +105,7 @@ exports.retrieveVersionById = async function (req, res, next) {
  */
 exports.streamVersionById = async function (req, res) {
   let heartbeatInterval;
-  
+
   try {
     const { stixId, modified } = req.params;
     const { retrieveContents } = req.query;
@@ -136,10 +136,10 @@ exports.streamVersionById = async function (req, res) {
 
     // Stream the data
     const stream = collectionsService.streamVersionById(stixId, modified, options);
-    
+
     for await (const chunk of stream) {
       if (res.destroyed) break; // Check if client disconnected
-      
+
       const event = `data: ${JSON.stringify(chunk)}\n\n`;
       res.write(event);
     }
@@ -151,9 +151,9 @@ exports.streamVersionById = async function (req, res) {
     }
   } catch (err) {
     logger.error('Stream error:', err);
-    
+
     if (heartbeatInterval) clearInterval(heartbeatInterval);
-    
+
     if (!res.headersSent) {
       res.status(500).json({ error: 'Stream initialization failed' });
     } else if (!res.destroyed) {

--- a/app/repository/_base.repository.js
+++ b/app/repository/_base.repository.js
@@ -201,6 +201,57 @@ class BaseRepository extends AbstractRepository {
   }
 
   /**
+   * Stream documents by their STIX ID and modified timestamp pairs
+   * @param {Array<{object_ref: string, object_modified: string}>} xMitreContents - Array of x_mitre_contents elements
+   * @yields {Object} Individual documents as they're retrieved
+   * @throws {BadlyFormattedParameterError} If stixId format is invalid
+   * @throws {DatabaseError} For other database errors
+   */
+  async *streamManyByIdAndModified(xMitreContents) {
+    const BATCH_SIZE = 500; // Smaller batches for streaming
+
+    for (let i = 0; i < xMitreContents.length; i += BATCH_SIZE) {
+      const batch = xMitreContents.slice(i, i + BATCH_SIZE);
+      const batchNum = Math.floor(i / BATCH_SIZE) + 1;
+      const totalBatches = Math.ceil(xMitreContents.length / BATCH_SIZE);
+
+      logger.debug(`[STREAM] Processing batch ${batchNum}/${totalBatches}`);
+
+      // Stream documents from this batch
+      yield* this._streamBatch(batch);
+    }
+  }
+
+  async *_streamBatch(xMitreContents) {
+    const startTime = Date.now();
+
+    try {
+      const conditions = xMitreContents.map(({ object_ref, object_modified }) => ({
+        'stix.id': object_ref,
+        'stix.modified': object_modified,
+      }));
+
+      // Use cursor for true streaming
+      const cursor = this.model.find({ $or: conditions }).lean().cursor();
+
+      let count = 0;
+      for (let doc = await cursor.next(); doc != null; doc = await cursor.next()) {
+        yield doc;
+        count++;
+      }
+
+      const queryTime = Date.now() - startTime;
+      logger.debug(`[STREAM] Batch streamed ${count} documents in ${queryTime}ms`);
+    } catch (err) {
+      logger.error(err);
+      if (err.name === 'CastError') {
+        throw new BadlyFormattedParameterError({ parameterName: 'stixId' });
+      }
+      throw new DatabaseError(err);
+    }
+  }
+
+  /**
    * Retrieve multiple documents by their STIX ID and modified timestamp pairs
    * @param {Array<{stixId: string, object_modified: string}>} xMitreContents - Array of STIX ID and modified timestamp pairs
    * @returns {Promise<Array<Object>>} Array of matching documents

--- a/app/services/attack-objects-service.js
+++ b/app/services/attack-objects-service.js
@@ -67,6 +67,30 @@ class AttackObjectsService extends BaseService {
   }
 
   /**
+   * Stream multiple attack objects by their version identifiers, handling relationships separately
+   * @param {Array<{object_ref: string, object_modified: string}>} xMitreContents - Array of x_mitre_contents elements
+   * @yields {Object} Attack objects and relationships with identities populated
+   */
+  async *streamBulkByIdAndModified(xMitreContents) {
+    const relationshipIdAndModified = xMitreContents.filter((content) =>
+      content.object_ref.startsWith('relationship'),
+    );
+    const nonRelationshipIdAndModified = xMitreContents.filter(
+      (content) => !content.object_ref.startsWith('relationship'),
+    );
+
+    // Stream relationships first
+    if (relationshipIdAndModified.length > 0) {
+      yield* relationshipsService.streamBulkByIdAndModified(relationshipIdAndModified);
+    }
+
+    // Then stream non-relationships
+    if (nonRelationshipIdAndModified.length > 0) {
+      yield* super.streamBulkByIdAndModified(nonRelationshipIdAndModified);
+    }
+  }
+
+  /**
    * Retrieve multiple attack objects by their version identifiers, handling relationships separately
    * @param {Array<{object_ref: string, modified: string}>} xMitreContents - Array of x_mitre_contents elements
    * @returns {Promise<Array<Object>>} Array of attack objects and relationships with identities populated


### PR DESCRIPTION
Add Server-Sent Events streaming for collection getter endpoints when `retrieveContents=true` to improve response time for large collections.

- Add `stream=true` query parameter to enable SSE streaming mode
- Implement `streamVersionById` controller method with SSE headers
- Add `streamVersionById` service method for incremental content delivery
- Enhance repository with `streamManyByIdAndModified` for batched streaming
- Maintain backward compatibility with existing non-streaming endpoints

Improves perceived performance by delivering collection data incrementally rather than waiting for full response assembly.