### PR TITLE
Add includeRefs Query Parameter to Analytics Endpoints

### DIFF
--- a/app/api/definitions/paths/analytics-paths.yml
+++ b/app/api/definitions/paths/analytics-paths.yml
@@ -92,6 +92,14 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: includeRefs
+          in: query
+          description: |
+            Whether to include related detection strategies and log sources.
+            Adds a `related_to` array containing related objects.
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: 'A list of analytics.'
@@ -155,6 +163,14 @@ paths:
               - all
               - latest
             default: latest
+        - name: includeRefs
+          in: query
+          description: |
+            Whether to include related detection strategies and log sources.
+            Adds a `related_to` array containing related objects.
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: 'A list of analytics matching the requested STIX id.'

--- a/app/controllers/analytics-controller.js
+++ b/app/controllers/analytics-controller.js
@@ -19,6 +19,7 @@ exports.retrieveAll = async function (req, res) {
     search: req.query.search,
     lastUpdatedBy: req.query.lastUpdatedBy,
     includePagination: req.query.includePagination,
+    includeRefs: req.query.includeRefs === 'true' || req.query.includeRefs === true,
   };
 
   try {
@@ -40,6 +41,7 @@ exports.retrieveAll = async function (req, res) {
 exports.retrieveById = async function (req, res) {
   const options = {
     versions: req.query.versions || 'latest',
+    includeRefs: req.query.includeRefs === 'true' || req.query.includeRefs === true,
   };
 
   try {

--- a/app/services/analytics-service.js
+++ b/app/services/analytics-service.js
@@ -3,7 +3,135 @@
 const analyticsRepository = require('../repository/analytics-repository');
 const BaseService = require('./_base.service');
 const { Analytic: AnalyticType } = require('../lib/types');
+const detectionStrategiesService = require('./detection-strategies-service');
+const logSourcesService = require('./log-sources-service');
 
-class AnalyticsService extends BaseService {}
+class AnalyticsService extends BaseService {
+  async retrieveAll(options) {
+    const results = await super.retrieveAll(options);
+
+    if (options.includeRefs) {
+      if (options.includePagination) {
+        await this.addRelatedObjectsToAll(results.data);
+      } else {
+        await this.addRelatedObjectsToAll(results);
+      }
+    }
+
+    return results;
+  }
+
+  async retrieveById(stixId, options) {
+    const results = await super.retrieveById(stixId, options);
+
+    if (options.includeRefs) {
+      await this.addRelatedObjectsToAll(results);
+    }
+
+    return results;
+  }
+
+  async addRelatedObjectsToAll(analytics) {
+    for (const analytic of analytics) {
+      await this.addRelatedObjects(analytic);
+    }
+  }
+
+  async addRelatedObjects(analytic) {
+    const relatedObjects = [];
+
+    try {
+      // Find detection strategies that reference this analytic
+      const detectionStrategies = await this.findDetectionStrategiesReferencingAnalytic(
+        analytic.stix.id,
+      );
+      for (const detectionStrategy of detectionStrategies) {
+        relatedObjects.push(
+          this.formatRelatedObject(detectionStrategy, 'x-mitre-detection-strategy'),
+        );
+      }
+
+      // Find log sources referenced by this analytic
+      const logSources = await this.findLogSourcesReferencedByAnalytic(analytic);
+      for (const logSource of logSources) {
+        relatedObjects.push(this.formatRelatedObject(logSource, 'x-mitre-log-source'));
+      }
+    } catch (err) {
+      // Log error but don't fail the main request
+      console.warn('Error fetching related objects for analytic:', err.message);
+    }
+
+    analytic.related_to = relatedObjects;
+  }
+
+  async findDetectionStrategiesReferencingAnalytic(analyticId) {
+    try {
+      // Query detection strategies where x_mitre_analytics array contains the analytic ID
+      const options = {
+        offset: 0,
+        limit: 0,
+        includeRevoked: false,
+        includeDeprecated: false,
+        includePagination: false,
+      };
+
+      // Get all detection strategies and filter in memory
+      // (BaseRepository doesn't have a direct way to query array contains)
+      const allStrategies = await detectionStrategiesService.retrieveAll(options);
+
+      return allStrategies.filter(
+        (strategy) =>
+          strategy.stix.x_mitre_analytics && strategy.stix.x_mitre_analytics.includes(analyticId),
+      );
+    } catch (err) {
+      console.warn('Error finding detection strategies:', err.message);
+      return [];
+    }
+  }
+
+  async findLogSourcesReferencedByAnalytic(analytic) {
+    try {
+      if (!analytic.stix.x_mitre_log_sources || analytic.stix.x_mitre_log_sources.length === 0) {
+        return [];
+      }
+
+      const logSourceIds = analytic.stix.x_mitre_log_sources.map((ref) => ref.ref);
+      const logSources = [];
+
+      // Fetch each log source by ID
+      for (const logSourceId of logSourceIds) {
+        try {
+          const logSourceResults = await logSourcesService.retrieveById(logSourceId, {
+            versions: 'latest',
+          });
+          if (logSourceResults.length > 0) {
+            logSources.push(logSourceResults[0]);
+          }
+        } catch (err) {
+          console.warn(`Error fetching log source ${logSourceId}:`, err.message);
+        }
+      }
+
+      return logSources;
+    } catch (err) {
+      console.warn('Error finding log sources:', err.message);
+      return [];
+    }
+  }
+
+  formatRelatedObject(obj, type) {
+    const attackId =
+      obj.stix.external_references && obj.stix.external_references.length > 0
+        ? obj.stix.external_references[0].external_id
+        : null;
+
+    return {
+      id: obj.stix.id,
+      name: obj.stix.name,
+      attack_id: attackId,
+      type: type,
+    };
+  }
+}
 
 module.exports = new AnalyticsService(AnalyticType, analyticsRepository);

--- a/app/tests/api/analytics/analytics-includeRefs.spec.js
+++ b/app/tests/api/analytics/analytics-includeRefs.spec.js
@@ -1,0 +1,469 @@
+const request = require('supertest');
+const { expect } = require('expect');
+
+const database = require('../../../lib/database-in-memory');
+const databaseConfiguration = require('../../../lib/database-configuration');
+
+const login = require('../../shared/login');
+
+const logger = require('../../../lib/logger');
+logger.level = 'debug';
+
+// Test data for analytics with log source references
+const analyticData = {
+  workspace: {
+    workflow: {
+      state: 'work-in-progress',
+    },
+  },
+  stix: {
+    name: 'test-analytic-with-refs',
+    spec_version: '2.1',
+    type: 'x-mitre-analytic',
+    external_references: [
+      {
+        source_name: 'mitre-attack',
+        external_id: 'AN0001',
+        url: 'https://attack.mitre.org/analytics/AN0001',
+      },
+    ],
+    object_marking_refs: ['marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168'],
+    created_by_ref: 'identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5',
+    x_mitre_version: '1.0',
+    x_mitre_attack_spec_version: '3.3.0',
+    x_mitre_platforms: ['windows'],
+    x_mitre_domains: ['enterprise-attack'],
+    x_mitre_log_sources: [
+      {
+        ref: 'x-mitre-log-source--test-log-source-1',
+        keys: ['perm-1'],
+      },
+    ],
+  },
+};
+
+// Test data for detection strategy that references an analytic
+const detectionStrategyData = {
+  workspace: {
+    workflow: {
+      state: 'work-in-progress',
+    },
+  },
+  stix: {
+    name: 'test-detection-strategy',
+    spec_version: '2.1',
+    type: 'x-mitre-detection-strategy',
+    external_references: [
+      {
+        source_name: 'mitre-attack',
+        external_id: 'DS0001',
+        url: 'https://attack.mitre.org/datasources/DS0001',
+      },
+    ],
+    object_marking_refs: ['marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168'],
+    created_by_ref: 'identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5',
+    x_mitre_version: '1.0',
+    x_mitre_attack_spec_version: '3.3.0',
+    x_mitre_domains: ['enterprise-attack'],
+    x_mitre_analytics: [], // Will be populated with analytic ID after creation
+  },
+};
+
+// Test data for log source
+const logSourceData = {
+  workspace: {
+    workflow: {
+      state: 'work-in-progress',
+    },
+  },
+  stix: {
+    id: 'x-mitre-log-source--test-log-source-1',
+    name: 'test-log-source',
+    spec_version: '2.1',
+    type: 'x-mitre-log-source',
+    external_references: [
+      {
+        source_name: 'mitre-attack',
+        external_id: 'LS0001',
+        url: 'https://attack.mitre.org/logsources/LS0001',
+      },
+    ],
+    object_marking_refs: ['marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168'],
+    created_by_ref: 'identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5',
+    x_mitre_version: '1.0',
+    x_mitre_attack_spec_version: '3.3.0',
+  },
+};
+
+describe('Analytics API - includeRefs Parameter', function () {
+  let app;
+  let passportCookie;
+  let createdAnalytic;
+  let createdDetectionStrategy;
+  let createdLogSource;
+
+  before(async function () {
+    // Establish the database connection
+    await database.initializeConnection();
+
+    // Check for a valid database configuration
+    await databaseConfiguration.checkSystemConfiguration();
+
+    // Initialize the express app
+    app = await require('../../../index').initializeApp();
+
+    // Log into the app
+    passportCookie = await login.loginAnonymous(app);
+  });
+
+  it('Setup: Create log source for testing', async function () {
+    const timestamp = new Date().toISOString();
+    logSourceData.stix.created = timestamp;
+    logSourceData.stix.modified = timestamp;
+
+    const res = await request(app)
+      .post('/api/log-sources')
+      .send(logSourceData)
+      .set('Accept', 'application/json')
+      .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+      .expect(201)
+      .expect('Content-Type', /json/);
+
+    createdLogSource = res.body;
+    expect(createdLogSource).toBeDefined();
+    expect(createdLogSource.stix.id).toBe('x-mitre-log-source--test-log-source-1');
+  });
+
+  it('Setup: Create analytic for testing', async function () {
+    const timestamp = new Date().toISOString();
+    analyticData.stix.created = timestamp;
+    analyticData.stix.modified = timestamp;
+
+    const res = await request(app)
+      .post('/api/analytics')
+      .send(analyticData)
+      .set('Accept', 'application/json')
+      .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+      .expect(201)
+      .expect('Content-Type', /json/);
+
+    createdAnalytic = res.body;
+    expect(createdAnalytic).toBeDefined();
+    expect(createdAnalytic.stix.id).toBeDefined();
+  });
+
+  it('Setup: Create detection strategy that references the analytic', async function () {
+    const timestamp = new Date().toISOString();
+    detectionStrategyData.stix.created = timestamp;
+    detectionStrategyData.stix.modified = timestamp;
+    detectionStrategyData.stix.x_mitre_analytics = [createdAnalytic.stix.id];
+
+    const res = await request(app)
+      .post('/api/detection-strategies')
+      .send(detectionStrategyData)
+      .set('Accept', 'application/json')
+      .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+      .expect(201)
+      .expect('Content-Type', /json/);
+
+    createdDetectionStrategy = res.body;
+    expect(createdDetectionStrategy).toBeDefined();
+    expect(createdDetectionStrategy.stix.id).toBeDefined();
+    expect(createdDetectionStrategy.stix.x_mitre_analytics).toContain(createdAnalytic.stix.id);
+  });
+
+  describe('GET /api/analytics with includeRefs=false (default)', function () {
+    it('should return analytics without related_to field', async function () {
+      const res = await request(app)
+        .get('/api/analytics')
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(200)
+        .expect('Content-Type', /json/);
+
+      const analytics = res.body;
+      expect(analytics).toBeDefined();
+      expect(Array.isArray(analytics)).toBe(true);
+      expect(analytics.length).toBeGreaterThan(0);
+
+      const testAnalytic = analytics.find((a) => a.stix.id === createdAnalytic.stix.id);
+      expect(testAnalytic).toBeDefined();
+      expect(testAnalytic.related_to).toBeUndefined();
+    });
+  });
+
+  describe('GET /api/analytics with includeRefs=true', function () {
+    it('should return analytics with related_to field containing detection strategies and log sources', async function () {
+      const res = await request(app)
+        .get('/api/analytics?includeRefs=true')
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(200)
+        .expect('Content-Type', /json/);
+
+      const analytics = res.body;
+      expect(analytics).toBeDefined();
+      expect(Array.isArray(analytics)).toBe(true);
+
+      const testAnalytic = analytics.find((a) => a.stix.id === createdAnalytic.stix.id);
+      expect(testAnalytic).toBeDefined();
+      expect(testAnalytic.related_to).toBeDefined();
+      expect(Array.isArray(testAnalytic.related_to)).toBe(true);
+
+      // Should contain the detection strategy
+      const detectionStrategyRef = testAnalytic.related_to.find(
+        (ref) => ref.type === 'x-mitre-detection-strategy',
+      );
+      expect(detectionStrategyRef).toBeDefined();
+      expect(detectionStrategyRef.id).toBe(createdDetectionStrategy.stix.id);
+      expect(detectionStrategyRef.name).toBe(createdDetectionStrategy.stix.name);
+      expect(detectionStrategyRef.attack_id).toBe('DS0001');
+      expect(detectionStrategyRef.type).toBe('x-mitre-detection-strategy');
+
+      // Should contain the log source
+      const logSourceRef = testAnalytic.related_to.find((ref) => ref.type === 'x-mitre-log-source');
+      expect(logSourceRef).toBeDefined();
+      expect(logSourceRef.id).toBe(createdLogSource.stix.id);
+      expect(logSourceRef.name).toBe(createdLogSource.stix.name);
+      expect(logSourceRef.attack_id).toBe('LS0001');
+      expect(logSourceRef.type).toBe('x-mitre-log-source');
+    });
+
+    it('should work with pagination', async function () {
+      const res = await request(app)
+        .get('/api/analytics?includeRefs=true&includePagination=true&limit=10')
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(200)
+        .expect('Content-Type', /json/);
+
+      const result = res.body;
+      expect(result).toBeDefined();
+      expect(result.pagination).toBeDefined();
+      expect(result.data).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+
+      const testAnalytic = result.data.find((a) => a.stix.id === createdAnalytic.stix.id);
+      if (testAnalytic) {
+        expect(testAnalytic.related_to).toBeDefined();
+        expect(Array.isArray(testAnalytic.related_to)).toBe(true);
+      }
+    });
+  });
+
+  describe('GET /api/analytics/:id with includeRefs parameter', function () {
+    it('should return analytic without related_to when includeRefs=false', async function () {
+      const res = await request(app)
+        .get(`/api/analytics/${createdAnalytic.stix.id}?includeRefs=false`)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(200)
+        .expect('Content-Type', /json/);
+
+      const analytics = res.body;
+      expect(analytics).toBeDefined();
+      expect(Array.isArray(analytics)).toBe(true);
+      expect(analytics.length).toBe(1);
+
+      const analytic = analytics[0];
+      expect(analytic.related_to).toBeUndefined();
+    });
+
+    it('should return analytic with related_to when includeRefs=true', async function () {
+      const res = await request(app)
+        .get(`/api/analytics/${createdAnalytic.stix.id}?includeRefs=true`)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(200)
+        .expect('Content-Type', /json/);
+
+      const analytics = res.body;
+      expect(analytics).toBeDefined();
+      expect(Array.isArray(analytics)).toBe(true);
+      expect(analytics.length).toBe(1);
+
+      const analytic = analytics[0];
+      expect(analytic.related_to).toBeDefined();
+      expect(Array.isArray(analytic.related_to)).toBe(true);
+      expect(analytic.related_to.length).toBe(2); // detection strategy + log source
+
+      // Verify detection strategy reference
+      const detectionStrategyRef = analytic.related_to.find(
+        (ref) => ref.type === 'x-mitre-detection-strategy',
+      );
+      expect(detectionStrategyRef).toBeDefined();
+      expect(detectionStrategyRef.id).toBe(createdDetectionStrategy.stix.id);
+      expect(detectionStrategyRef.name).toBe(createdDetectionStrategy.stix.name);
+
+      // Verify log source reference
+      const logSourceRef = analytic.related_to.find((ref) => ref.type === 'x-mitre-log-source');
+      expect(logSourceRef).toBeDefined();
+      expect(logSourceRef.id).toBe(createdLogSource.stix.id);
+      expect(logSourceRef.name).toBe(createdLogSource.stix.name);
+    });
+
+    it('should work with versions=all parameter', async function () {
+      const res = await request(app)
+        .get(`/api/analytics/${createdAnalytic.stix.id}?versions=all&includeRefs=true`)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(200)
+        .expect('Content-Type', /json/);
+
+      const analytics = res.body;
+      expect(analytics).toBeDefined();
+      expect(Array.isArray(analytics)).toBe(true);
+      expect(analytics.length).toBeGreaterThanOrEqual(1);
+
+      // All versions should have related_to populated
+      analytics.forEach((analytic) => {
+        expect(analytic.related_to).toBeDefined();
+        expect(Array.isArray(analytic.related_to)).toBe(true);
+      });
+    });
+  });
+
+  describe('Edge cases and error handling', function () {
+    it('should handle analytics with no log source references', async function () {
+      // Create an analytic without log source references
+      const analyticWithoutRefs = {
+        ...analyticData,
+        stix: {
+          ...analyticData.stix,
+          name: 'analytic-without-refs',
+          x_mitre_log_sources: [],
+          created: new Date().toISOString(),
+          modified: new Date().toISOString(),
+        },
+      };
+
+      const createRes = await request(app)
+        .post('/api/analytics')
+        .send(analyticWithoutRefs)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(201);
+
+      const createdAnalyticWithoutRefs = createRes.body;
+
+      const res = await request(app)
+        .get(`/api/analytics/${createdAnalyticWithoutRefs.stix.id}?includeRefs=true`)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(200);
+
+      const analytics = res.body;
+      const analytic = analytics[0];
+      expect(analytic.related_to).toBeDefined();
+      expect(Array.isArray(analytic.related_to)).toBe(true);
+      // Should only contain detection strategies that reference it, no log sources
+      const logSourceRefs = analytic.related_to.filter((ref) => ref.type === 'x-mitre-log-source');
+      expect(logSourceRefs.length).toBe(0);
+    });
+
+    it('should handle non-existent log source references gracefully', async function () {
+      // Create an analytic with a non-existent log source reference
+      const analyticWithBadRef = {
+        ...analyticData,
+        stix: {
+          ...analyticData.stix,
+          name: 'analytic-with-bad-ref',
+          x_mitre_log_sources: [
+            {
+              ref: 'x-mitre-log-source--non-existent',
+              keys: ['perm-1'],
+            },
+          ],
+          created: new Date().toISOString(),
+          modified: new Date().toISOString(),
+        },
+      };
+
+      const createRes = await request(app)
+        .post('/api/analytics')
+        .send(analyticWithBadRef)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(201);
+
+      const createdAnalyticWithBadRef = createRes.body;
+
+      const res = await request(app)
+        .get(`/api/analytics/${createdAnalyticWithBadRef.stix.id}?includeRefs=true`)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(200);
+
+      const analytics = res.body;
+      const analytic = analytics[0];
+      expect(analytic.related_to).toBeDefined();
+      expect(Array.isArray(analytic.related_to)).toBe(true);
+      // Should not contain the non-existent log source
+      const logSourceRefs = analytic.related_to.filter((ref) => ref.type === 'x-mitre-log-source');
+      expect(logSourceRefs.length).toBe(0);
+    });
+
+    it('should handle analytics with missing external references', async function () {
+      // Create objects without external references
+      const logSourceWithoutExtRefs = {
+        ...logSourceData,
+        stix: {
+          ...logSourceData.stix,
+          id: 'x-mitre-log-source--no-ext-refs',
+          name: 'log-source-no-ext-refs',
+          external_references: [],
+          created: new Date().toISOString(),
+          modified: new Date().toISOString(),
+        },
+      };
+
+      await request(app)
+        .post('/api/log-sources')
+        .send(logSourceWithoutExtRefs)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(201);
+
+      const analyticWithNoExtRefLogSource = {
+        ...analyticData,
+        stix: {
+          ...analyticData.stix,
+          name: 'analytic-with-no-ext-ref-log-source',
+          x_mitre_log_sources: [
+            {
+              ref: 'x-mitre-log-source--no-ext-refs',
+              keys: ['perm-1'],
+            },
+          ],
+          created: new Date().toISOString(),
+          modified: new Date().toISOString(),
+        },
+      };
+
+      const createRes = await request(app)
+        .post('/api/analytics')
+        .send(analyticWithNoExtRefLogSource)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(201);
+
+      const createdAnalyticWithNoExtRefLogSource = createRes.body;
+
+      const res = await request(app)
+        .get(`/api/analytics/${createdAnalyticWithNoExtRefLogSource.stix.id}?includeRefs=true`)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(200);
+
+      const analytics = res.body;
+      const analytic = analytics[0];
+      const logSourceRef = analytic.related_to.find((ref) => ref.type === 'x-mitre-log-source');
+      expect(logSourceRef).toBeDefined();
+      expect(logSourceRef.attack_id).toBeNull();
+    });
+  });
+
+  after(async function () {
+    await database.closeConnection();
+  });
+});


### PR DESCRIPTION
  ## Summary

  This PR adds an optional `includeRefs` query parameter to analytics endpoints that allows clients to retrieve related detection strategies and log sources along with analytics data. When `includeRefs=true`, the response
   includes a `related_to` array containing information about objects that have relationships with the requested analytics.

  ## Changes Made

  ### API Endpoints Modified
  - `GET /api/analytics` - now accepts `includeRefs` boolean parameter
  - `GET /api/analytics/{stixId}` - now accepts `includeRefs` boolean parameter

  ### New Response Format
  When `includeRefs=true`, each analytic object includes a `related_to` array with the following structure:
  ```json5
  {
    "stix": { /** analytic keys */ },
    "related_to": [
      // the following detection references this analytic
      {
        "id": "x-mitre-detection-strategy--abc123",
        "name": "Example Detection Strategy",
        "attack_id": "DS0001",
        "type": "x-mitre-detection-strategy"
      },
      // this analytic references the following log source
      {
        "id": "x-mitre-log-source--def456",
        "name": "Example Log Source",
        "attack_id": "LS0001",
        "type": "x-mitre-log-source"
      }
    ]
  }
```

### Implementation Logic

- **Detection Strategies**: Finds strategies where `x_mitre_analytics` array contains the analytic's STIX ID
- **Log Sources**: Finds log sources referenced in the analytic's `x_mitre_log_sources` array
- Overrides `retrieveAll` and `retrieveById` methods in `AnalyticsService`
- Uses existing service methods to maintain consistency

### Testing

Added test coverage including:
  
- Default behavior without `includeRefs` parameter
- Functionality with `includeRefs=true` for both endpoints
- Pagination compatibility
- Version parameter compatibility (`versions=all`)
- Edge cases: missing references, non-existent objects
- Error resilience: malformed external references

### Backwards Compatibility

  - No breaking changes - existing API behavior unchanged
  - New parameter is optional
  - Response format only extends existing structure

### Documentation

  - Updated OpenAPI spec files
  - Test cases serve as usage examples