### PR TITLE
419 improve analytic searching by including detection strategy results

### DIFF
--- a/app/repository/analytics-repository.js
+++ b/app/repository/analytics-repository.js
@@ -2,7 +2,115 @@
 
 const BaseRepository = require('./_base.repository');
 const Analytic = require('../models/analytic-model');
+const detectionStrategiesRepository = require('./detection-strategies-repository');
+const regexValidator = require('../lib/regex');
+const { lastUpdatedByQueryHelper } = require('../lib/request-parameter-helper');
+const { DatabaseError } = require('../exceptions');
 
-class AnalyticsRepository extends BaseRepository {}
+class AnalyticsRepository extends BaseRepository {
+  async retrieveAll(options) {
+    try {
+      // Build the query
+      const query = {};
+
+      // Build the query
+      if (!options.includeRevoked) {
+        query['stix.revoked'] = { $in: [null, false] };
+      }
+      if (!options.includeDeprecated) {
+        query['stix.x_mitre_deprecated'] = { $in: [null, false] };
+      }
+      if (typeof options.state !== 'undefined') {
+        if (Array.isArray(options.state)) {
+          query['workspace.workflow.state'] = { $in: options.state };
+        } else {
+          query['workspace.workflow.state'] = options.state;
+        }
+      }
+      if (typeof options.domain !== 'undefined') {
+        if (Array.isArray(options.domain)) {
+          query['stix.x_mitre_domains'] = { $in: options.domain };
+        } else {
+          query['stix.x_mitre_domains'] = options.domain;
+        }
+      }
+      if (typeof options.platform !== 'undefined') {
+        if (Array.isArray(options.platform)) {
+          query['stix.x_mitre_platforms'] = { $in: options.platform };
+        } else {
+          query['stix.x_mitre_platforms'] = options.platform;
+        }
+      }
+      if (typeof options.lastUpdatedBy !== 'undefined') {
+        query['workspace.workflow.created_by_user_account'] = lastUpdatedByQueryHelper(
+          options.lastUpdatedBy,
+        );
+      }
+
+      // Build the aggregation
+      // - Group the documents by stix.id, sorted by stix.modified
+      // - Use the first document in each group (according to the value of stix.modified)
+      // - Then apply query, skip and limit options
+      const aggregation = [
+        { $sort: { 'stix.id': 1, 'stix.modified': -1 } },
+        { $group: { _id: '$stix.id', document: { $first: '$$ROOT' } } },
+        { $replaceRoot: { newRoot: '$document' } },
+        { $sort: { 'stix.id': 1 } },
+        { $match: query },
+      ];
+
+      if (typeof options.search !== 'undefined') {
+        options.search = regexValidator.sanitizeRegex(options.search);
+
+        // Get analytic references from detection strategies that match the search term
+        const analyticRefs = await detectionStrategiesRepository.findAnalyticRefsBySearch(
+          options.search,
+          {
+            includeRevoked: options.includeRevoked,
+            includeDeprecated: options.includeDeprecated,
+          },
+        );
+
+        const match = {
+          $match: {
+            $or: [
+              { 'stix.name': { $regex: options.search, $options: 'i' } },
+              { 'stix.description': { $regex: options.search, $options: 'i' } },
+              { 'workspace.attack_id': { $regex: options.search, $options: 'i' } },
+              ...(analyticRefs.length > 0 ? [{ 'stix.id': { $in: analyticRefs } }] : []),
+            ],
+          },
+        };
+        aggregation.push(match);
+      }
+
+      // Get the total count of documents, pre-limit
+      const totalCount = await this.model.aggregate(aggregation).count('totalCount').exec();
+
+      if (options.offset) {
+        aggregation.push({ $skip: options.offset });
+      } else {
+        aggregation.push({ $skip: 0 });
+      }
+
+      if (options.limit) {
+        aggregation.push({ $limit: options.limit });
+      }
+
+      // Retrieve the documents
+      const documents = await this.model.aggregate(aggregation).exec();
+
+      // Return data in the format previously given by $facet
+      return [
+        {
+          totalCount: [{ totalCount: totalCount[0]?.totalCount || 0 }],
+          documents: documents,
+        },
+      ];
+    } catch (err) {
+      throw new DatabaseError(err);
+    }
+  }
+}
 
 module.exports = new AnalyticsRepository(Analytic);

--- a/app/repository/detection-strategies-repository.js
+++ b/app/repository/detection-strategies-repository.js
@@ -2,7 +2,68 @@
 
 const BaseRepository = require('./_base.repository');
 const DetectionStrategy = require('../models/detection-strategy-model');
+const regexValidator = require('../lib/regex');
+const { DatabaseError } = require('../exceptions');
 
-class DetectionStrategiesRepository extends BaseRepository {}
+class DetectionStrategiesRepository extends BaseRepository {
+  /**
+   * Find analytic references from detection strategies that match the search term
+   * @param {string} searchTerm - The search term to match against strategy names
+   * @param {Object} options - Search options (includeRevoked, includeDeprecated)
+   * @returns {Promise<string[]>} Array of analytic STIX IDs
+   */
+  async findAnalyticRefsBySearch(searchTerm, options = {}) {
+    try {
+      if (!searchTerm) {
+        return [];
+      }
+
+      const sanitizedSearch = regexValidator.sanitizeRegex(searchTerm);
+
+      // Build query for detection strategies matching the search term
+      const query = {
+        'stix.name': { $regex: sanitizedSearch, $options: 'i' },
+      };
+
+      if (!options.includeRevoked) {
+        query['stix.revoked'] = { $in: [null, false] };
+      }
+      if (!options.includeDeprecated) {
+        query['stix.x_mitre_deprecated'] = { $in: [null, false] };
+      }
+
+      const matchingStrategies = await this.model
+        .find(query)
+        .sort({ 'stix.id': 1, 'stix.modified': -1 })
+        .exec();
+
+      // Get latest version of each detection strategy and extract analytic refs
+      const strategyGroups = {};
+      matchingStrategies.forEach((strategy) => {
+        const stixId = strategy.stix.id;
+        if (
+          !strategyGroups[stixId] ||
+          strategy.stix.modified > strategyGroups[stixId].stix.modified
+        ) {
+          strategyGroups[stixId] = strategy;
+        }
+      });
+
+      const analyticRefs = [];
+      Object.values(strategyGroups).forEach((strategy) => {
+        if (
+          strategy.stix.x_mitre_analytic_refs &&
+          Array.isArray(strategy.stix.x_mitre_analytic_refs)
+        ) {
+          analyticRefs.push(...strategy.stix.x_mitre_analytic_refs);
+        }
+      });
+
+      return analyticRefs;
+    } catch (err) {
+      throw new DatabaseError(err);
+    }
+  }
+}
 
 module.exports = new DetectionStrategiesRepository(DetectionStrategy);

--- a/app/tests/api/analytics/analytics-spec.js
+++ b/app/tests/api/analytics/analytics-spec.js
@@ -498,7 +498,7 @@ describe('Analytics API', function () {
           .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
           .expect(204);
       }
-      
+
       if (searchTestAnalytic) {
         await request(app)
           .delete('/api/analytics/' + searchTestAnalytic.stix.id)

--- a/app/tests/api/analytics/analytics-spec.js
+++ b/app/tests/api/analytics/analytics-spec.js
@@ -364,6 +364,150 @@ describe('Analytics API', function () {
       .expect(204);
   });
 
+  describe('Search functionality with detection strategies', function () {
+    // Test data for detection strategy search functionality
+    const detectionStrategyData = {
+      workspace: {
+        workflow: {
+          state: 'work-in-progress',
+        },
+      },
+      stix: {
+        name: 'Network Connection Creation Detection Strategy',
+        spec_version: '2.1',
+        type: 'x-mitre-detection-strategy',
+        description: 'Strategy for detecting network connections',
+        object_marking_refs: ['marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168'],
+        created_by_ref: 'identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5',
+        x_mitre_version: '1.0',
+        x_mitre_attack_spec_version: '3.3.0',
+        x_mitre_domains: ['enterprise-attack'],
+        x_mitre_analytic_refs: [],
+      },
+    };
+
+    let searchTestAnalytic;
+    let searchTestDetectionStrategy;
+
+    it('POST /api/analytics creates a search test analytic', async function () {
+      const timestamp = new Date().toISOString();
+      const searchAnalyticData = _.cloneDeep(initialObjectData);
+      searchAnalyticData.stix.name = 'Search Test Analytic';
+      searchAnalyticData.stix.created = timestamp;
+      searchAnalyticData.stix.modified = timestamp;
+
+      const res = await request(app)
+        .post('/api/analytics')
+        .send(searchAnalyticData)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(201)
+        .expect('Content-Type', /json/);
+
+      searchTestAnalytic = res.body;
+      expect(searchTestAnalytic).toBeDefined();
+      expect(searchTestAnalytic.stix.id).toBeDefined();
+    });
+
+    it('POST /api/detection-strategies creates a detection strategy that references the analytic', async function () {
+      const timestamp = new Date().toISOString();
+      detectionStrategyData.stix.created = timestamp;
+      detectionStrategyData.stix.modified = timestamp;
+      detectionStrategyData.stix.x_mitre_analytic_refs = [searchTestAnalytic.stix.id];
+
+      const res = await request(app)
+        .post('/api/detection-strategies')
+        .send(detectionStrategyData)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(201)
+        .expect('Content-Type', /json/);
+
+      searchTestDetectionStrategy = res.body;
+      expect(searchTestDetectionStrategy).toBeDefined();
+      expect(searchTestDetectionStrategy.stix.id).toBeDefined();
+      expect(searchTestDetectionStrategy.stix.x_mitre_analytic_refs).toContain(
+        searchTestAnalytic.stix.id,
+      );
+    });
+
+    it('GET /api/analytics?search should find analytic by its own name', async function () {
+      const res = await request(app)
+        .get('/api/analytics?search=Search Test')
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(200)
+        .expect('Content-Type', /json/);
+
+      const analytics = res.body;
+      expect(analytics).toBeDefined();
+      expect(Array.isArray(analytics)).toBe(true);
+      expect(analytics.length).toBe(1);
+      expect(analytics[0].stix.id).toBe(searchTestAnalytic.stix.id);
+    });
+
+    it('GET /api/analytics?search should find analytic by detection strategy name', async function () {
+      const res = await request(app)
+        .get('/api/analytics?search=Network Connection Creation')
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(200)
+        .expect('Content-Type', /json/);
+
+      const analytics = res.body;
+      expect(analytics).toBeDefined();
+      expect(Array.isArray(analytics)).toBe(true);
+      expect(analytics.length).toBe(1);
+      expect(analytics[0].stix.id).toBe(searchTestAnalytic.stix.id);
+    });
+
+    it('GET /api/analytics?search should find analytic by partial detection strategy name', async function () {
+      const res = await request(app)
+        .get('/api/analytics?search=Network Connection')
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(200)
+        .expect('Content-Type', /json/);
+
+      const analytics = res.body;
+      expect(analytics).toBeDefined();
+      expect(Array.isArray(analytics)).toBe(true);
+      expect(analytics.length).toBe(1);
+      expect(analytics[0].stix.id).toBe(searchTestAnalytic.stix.id);
+    });
+
+    it('GET /api/analytics?search should not find analytic with non-existent search term', async function () {
+      const res = await request(app)
+        .get('/api/analytics?search=NonExistentTerm')
+        .set('Accept', 'application/json')
+        .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+        .expect(200)
+        .expect('Content-Type', /json/);
+
+      const analytics = res.body;
+      expect(analytics).toBeDefined();
+      expect(Array.isArray(analytics)).toBe(true);
+      expect(analytics.length).toBe(0);
+    });
+
+    after(async function () {
+      // Clean up test data
+      if (searchTestDetectionStrategy) {
+        await request(app)
+          .delete('/api/detection-strategies/' + searchTestDetectionStrategy.stix.id)
+          .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+          .expect(204);
+      }
+      
+      if (searchTestAnalytic) {
+        await request(app)
+          .delete('/api/analytics/' + searchTestAnalytic.stix.id)
+          .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+          .expect(204);
+      }
+    });
+  });
+
   it('GET /api/analytics returns an empty array of analytics', async function () {
     const res = await request(app)
       .get('/api/analytics')


### PR DESCRIPTION
Closes #419 

## Summary

Enhanced analytics search to include detection strategy names, addressing the challenge of finding analytics with generic names like "Analytic 0001" by their more meaningful associated detection strategies.

## Problem

Analytics in the ATT&CK Workbench follow a generic naming convention ("Analytic 0001", "Analytic 0002", etc.), making them difficult to discover through search. Users typically identify analytics through their associated detection strategies, which have descriptive names like "Network Connection Creation Detection Strategy".

## Solution

Extended the existing analytics search functionality to include detection strategy names. When users search for analytics, the system now searches both the analytics themselves and their associated detection strategies, returning analytics that match either criteria.

For example, searching for "Network Connection" will now find analytics associated with the "Network Connection Creation Detection Strategy", even if the analytic itself is named "Analytic 0042".

## Implementation

- Added `findAnalyticRefsBySearch()` method to the `DetectionStrategiesRepository` to maintain proper DAO separation
- Enhanced `AnalyticsRepository` to query detection strategies and include their referenced analytics in search results
- Maintained backward compatibility - all existing search functionality continues to work unchanged
- Added unit tests with proper cleanup using lifecycle hooks

The search now works by combining results from both direct analytic matches and detection strategy name matches, giving users multiple ways to discover the analytics they need.