### PR TITLE
Allow WIP saves for detection strategies and campaigns

### DIFF
--- a/app/api/definitions/components/campaigns.yml
+++ b/app/api/definitions/components/campaigns.yml
@@ -17,10 +17,6 @@ components:
         - type: object
           required:
             - name
-            - first_seen
-            - last_seen
-            - x_mitre_first_seen_citation
-            - x_mitre_last_seen_citation
           properties:
             # campaign specific properties
             name:

--- a/app/api/definitions/components/campaigns.yml
+++ b/app/api/definitions/components/campaigns.yml
@@ -17,6 +17,10 @@ components:
         - type: object
           required:
             - name
+            - first_seen
+            - last_seen
+            - x_mitre_first_seen_citation
+            - x_mitre_last_seen_citation
           properties:
             # campaign specific properties
             name:

--- a/app/config/config.js
+++ b/app/config/config.js
@@ -205,13 +205,13 @@ function loadConfig() {
       withAttackDataModel: {
         doc: 'Enable validation of POST and PUT request bodies using the ATT&CK Data Model',
         format: Boolean,
-        default: false,
+        default: true,
         env: 'VALIDATE_WITH_ADM_SCHEMAS',
       },
       withOpenApi: {
         doc: 'Enable validation of POST and PUT request bodies using the legacy OpenAPI YAML-based validation schemas',
         format: Boolean,
-        default: true,
+        default: false,
         env: 'VALIDATE_WITH_LEGACY_SCHEMAS',
       },
     },

--- a/app/lib/error-handler.js
+++ b/app/lib/error-handler.js
@@ -53,7 +53,7 @@ exports.requestValidation = function (err, req, res, next) {
     logger.warn('Request failed validation');
     try {
       logger.info(JSON.stringify(err));
-    } catch (e) {
+    } catch {
       logger.info(err.message);
     }
     return res.status(err.status).send(err.message);

--- a/app/lib/error-handler.js
+++ b/app/lib/error-handler.js
@@ -51,8 +51,12 @@ exports.bodyParser = function (err, req, res, next) {
 exports.requestValidation = function (err, req, res, next) {
   if (err.status && err.message) {
     logger.warn('Request failed validation');
-    logger.info(JSON.stringify(err));
-    res.status(err.status).send(err.message);
+    try {
+      logger.info(JSON.stringify(err));
+    } catch (e) {
+      logger.info(err.message);
+    }
+    return res.status(err.status).send(err.message);
   } else {
     next(err);
   }

--- a/app/repository/_base.repository.js
+++ b/app/repository/_base.repository.js
@@ -87,14 +87,13 @@ class BaseRepository extends AbstractRepository {
       // Get the total count of documents, pre-limit
       const totalCount = await this.model.aggregate(aggregation).count('totalCount').exec();
 
-      if (options.offset) {
-        aggregation.push({ $skip: options.offset });
-      } else {
-        aggregation.push({ $skip: 0 });
-      }
+      // Ensure offset and limit are integers
+      const offsetVal = Number(options.offset);
+      aggregation.push({ $skip: Number.isFinite(offsetVal) && offsetVal > 0 ? offsetVal : 0 });
 
-      if (options.limit) {
-        aggregation.push({ $limit: options.limit });
+      const limitVal = Number(options.limit);
+      if (Number.isFinite(limitVal) && limitVal > 0) {
+        aggregation.push({ $limit: limitVal });
       }
 
       // Aggregation bypasses Mongoose toJSON/toObject transforms, so we

--- a/app/repository/references-repository.js
+++ b/app/repository/references-repository.js
@@ -34,14 +34,13 @@ class ReferencesRepository {
     // Get the total count of documents, pre-limit
     const totalCount = await this.model.aggregate(aggregation).count('totalCount').exec();
 
-    if (options.offset) {
-      aggregation.push({ $skip: options.offset });
-    } else {
-      aggregation.push({ $skip: 0 });
-    }
+    // Ensure offset and limit are integers
+    const offsetVal = Number(options.offset);
+    aggregation.push({ $skip: Number.isFinite(offsetVal) && offsetVal > 0 ? offsetVal : 0 });
 
-    if (options.limit) {
-      aggregation.push({ $limit: options.limit });
+    const limitVal = Number(options.limit);
+    if (Number.isFinite(limitVal) && limitVal > 0) {
+      aggregation.push({ $limit: limitVal });
     }
 
     // Retrieve the documents

--- a/app/services/stix/detection-strategies-service.js
+++ b/app/services/stix/detection-strategies-service.js
@@ -44,7 +44,10 @@ class DetectionStrategiesService extends BaseService {
    * Detects if this is a new version and tracks removed relationships
    */
   async beforeCreate(data) {
-    this._assertAnalyticRefsAreUnique(data);
+    const refs = data?.stix?.x_mitre_analytic_refs;
+    if (Array.isArray(refs)) {
+      this._assertAnalyticRefsAreUnique(data);
+    }
 
     // Initialize workspace if not present
     if (!data.workspace) {
@@ -167,7 +170,10 @@ class DetectionStrategiesService extends BaseService {
    */
   // eslint-disable-next-line no-unused-vars
   async beforeUpdate(stixId, stixModified, data, existingDocument, options) {
-    this._assertAnalyticRefsAreUnique(data);
+    const refs = data?.stix?.x_mitre_analytic_refs;
+    if (Array.isArray(refs)) {
+      this._assertAnalyticRefsAreUnique(data);
+    }
 
     const oldAnalyticRefs = existingDocument.stix?.x_mitre_analytic_refs || [];
     const newAnalyticRefs = data.stix?.x_mitre_analytic_refs || [];


### PR DESCRIPTION
Enables user to save campaign objects in WIP state when first-seen, last-seen, first-seen-citation and last-seen citation fields are missing and when validation is being done through the attack data model. Addresses #456 

Enables user to save detection strategies in WIP state when `x_mitre_analytic_refs` is missing. Addresses #457 

Ensure limit and offset params are integers and do not get passed as strings

