### PR TITLE
feat(openapi): make spec_version/created/modified optional; relax campaigns fields; fix detection_strategies analytic_refs crash

### DIFF
--- a/app/api/definitions/components/campaigns.yml
+++ b/app/api/definitions/components/campaigns.yml
@@ -17,10 +17,6 @@ components:
         - type: object
           required:
             - name
-            - first_seen
-            - last_seen
-            - x_mitre_first_seen_citation
-            - x_mitre_last_seen_citation
           properties:
             # campaign specific properties
             name:

--- a/app/api/definitions/components/stix-common.yml
+++ b/app/api/definitions/components/stix-common.yml
@@ -4,9 +4,6 @@ components:
       type: object
       required:
         - type
-        - spec_version
-        - created
-        - modified
       properties:
         # STIX common properties
         type:

--- a/app/lib/assertions.js
+++ b/app/lib/assertions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const { BadlyFormattedParameterError } = require('../exceptions');
 
 /**
  * Service-layer assertion utilities
@@ -8,6 +8,9 @@ const assert = require('assert');
  * This module provides assertion helpers for validating internal invariants in the service layer.
  * Unlike middleware validation (which validates user input), these assertions check for programming
  * errors and data integrity issues that should never occur in normal operation.
+ *
+ * These assertions throw BadlyFormattedParameterError (resulting in 400 responses for direct API calls)
+ * and are caught and categorized as validation errors during bulk import operations.
  *
  * Usage:
  * ```
@@ -19,21 +22,32 @@ const assert = require('assert');
 /**
  * Assert that an array contains only unique values
  *
- * @param {Array} array - The array to check for uniqueness
+ * @param {Array|undefined|null} array - The array to check for uniqueness (undefined/null are allowed and skip validation)
  * @param {string} fieldName - Name of the field being checked (for error messages)
  * @param {object} context - Additional context to include in error message (e.g., { stixId: '...' })
- * @throws {AssertionError} If array contains duplicate values
+ * @throws {BadlyFormattedParameterError} If array is provided but not an array type, or contains duplicate values
  *
  * @example
  * assertUnique(['a', 'b', 'c'], 'analytic_refs', { stixId: 'detection-strategy--123' });
  * // Passes
  *
+ * assertUnique(undefined, 'analytic_refs', { stixId: 'detection-strategy--123' });
+ * // Passes (undefined is allowed - field is optional)
+ *
  * assertUnique(['a', 'b', 'a'], 'analytic_refs', { stixId: 'detection-strategy--123' });
- * // Throws: AssertionError: analytic_refs must contain unique values. Found duplicates in detection-strategy--123
+ * // Throws: BadlyFormattedParameterError: analytic_refs must contain unique values. Found duplicates in detection-strategy--123
  */
 function assertUnique(array, fieldName, context = {}) {
+  // Allow undefined/null - the field may be optional
+  if (array === undefined || array === null) {
+    return;
+  }
+
   if (!Array.isArray(array)) {
-    assert.fail(`${fieldName} must be an array, got ${typeof array}`);
+    throw new BadlyFormattedParameterError({
+      parameterName: fieldName,
+      message: `${fieldName} must be an array, got ${typeof array}`,
+    });
   }
 
   if (array.length === 0) {
@@ -43,11 +57,12 @@ function assertUnique(array, fieldName, context = {}) {
   const uniqueValues = new Set(array);
   const contextStr = context.stixId ? ` in ${context.stixId}` : '';
 
-  assert.strictEqual(
-    uniqueValues.size,
-    array.length,
-    `${fieldName} must contain unique values. Found duplicates${contextStr}`,
-  );
+  if (uniqueValues.size !== array.length) {
+    throw new BadlyFormattedParameterError({
+      parameterName: fieldName,
+      message: `${fieldName} must contain unique values. Found duplicates${contextStr}`,
+    });
+  }
 }
 
 module.exports = {

--- a/app/services/meta-classes/base.service.js
+++ b/app/services/meta-classes/base.service.js
@@ -514,8 +514,21 @@ class BaseService extends ServiceWithHooks {
       if (!data.stix.id) {
         data.stix.id = `${data.stix.type}--${uuid.v4()}`;
       }
+      if (!data.stix.created) {
+        data.stix.created = new Date().toISOString();
+      }
       data.stix.created_by_ref = organizationIdentityRef;
       data.stix.x_mitre_modified_by_ref = organizationIdentityRef;
+    }
+
+    // Set modified timestamp if not set by client — set for both new and existing objects
+    if (!data.stix.modified) {
+      data.stix.modified = new Date().toISOString();
+    }
+
+    // Set default spec_version if not provided by client
+    if (!data.stix.spec_version) {
+      data.stix.spec_version = '2.1';
     }
 
     // 3b. Metadata fields

--- a/app/tests/api/groups/groups-input-validation.spec.js
+++ b/app/tests/api/groups/groups-input-validation.spec.js
@@ -160,7 +160,7 @@ describe('Groups API Input Validation', function () {
   });
 
   executeTests(() => app, 'stix.type', { required: true });
-  executeTests(() => app, 'stix.spec_version', { required: true });
+  executeTests(() => app, 'stix.spec_version', { required: false });
   executeTests(() => app, 'stix.name', { required: true });
   executeTests(() => app, 'stix.description');
   executeTests(() => app, 'stix.x_mitre_modified_by_ref');


### PR DESCRIPTION
## Features

- `spec_version`, `created`, and `modified` are now optional; server sets defaults when omitted

## Fixes

- **Campaigns**: `first_seen`, `last_seen`, `x_mitre_first_seen_citation`, and `x_mitre_last_seen_citation` are no long flagged as required in the OpenAPI spec files. They are now considered optional. Defers to the ADM for status-based validation. Addresses https://github.com/center-for-threat-informed-defense/attack-workbench-rest-api/issues/456
- **Detection Strategies**: When `analytic_refs` is omitted/unset, the server will no longer raise an assertion error and crash per https://github.com/center-for-threat-informed-defense/attack-workbench-rest-api/issues/457