### PR TITLE
feat: implement workflows for technique conversions

### DIFF
--- a/app/api/definitions/components/workflow-response.yml
+++ b/app/api/definitions/components/workflow-response.yml
@@ -1,0 +1,95 @@
+components:
+  schemas:
+    workflow-response:
+      type: object
+      description: |
+        Universal response envelope for all workflow endpoints (revoke, convert-to-subtechnique,
+        convert-to-technique). Provides full visibility into every object that was created,
+        modified, deprecated, or deleted as a consequence of the request.
+      required:
+        - workflow
+        - primary
+        - sideEffects
+        - warnings
+      properties:
+        workflow:
+          type: string
+          description: 'Discriminator identifying which workflow produced this response.'
+          enum:
+            - revoke
+            - convert-to-subtechnique
+            - convert-to-technique
+          example: 'revoke'
+        primary:
+          type: object
+          description: 'The primary object that the user acted on, in its post-workflow state.'
+          properties:
+            workspace:
+              $ref: 'workspace.yml#/components/schemas/workspace'
+            stix:
+              $ref: 'stix-common.yml#/components/schemas/stix-common'
+        sideEffects:
+          $ref: '#/components/schemas/side-effects'
+        warnings:
+          type: array
+          description: 'Non-fatal warning messages generated during the workflow.'
+          items:
+            type: string
+          example: []
+
+    side-effects:
+      type: object
+      description: 'Objects created, modified, deprecated, or deleted as a consequence of the workflow.'
+      required:
+        - created
+        - modified
+        - deprecated
+        - deleted
+      properties:
+        created:
+          type: array
+          description: 'Objects created during the workflow (e.g., revoked-by relationships, subtechnique-of relationships, transferred relationships).'
+          items:
+            type: object
+            properties:
+              workspace:
+                $ref: 'workspace.yml#/components/schemas/workspace'
+              stix:
+                $ref: 'stix-common.yml#/components/schemas/stix-common'
+        modified:
+          type: array
+          description: 'Objects modified (new version saved) during the workflow.'
+          items:
+            type: object
+            properties:
+              workspace:
+                $ref: 'workspace.yml#/components/schemas/workspace'
+              stix:
+                $ref: 'stix-common.yml#/components/schemas/stix-common'
+        deprecated:
+          type: array
+          description: 'Objects deprecated (new version saved with x_mitre_deprecated=true) during the workflow.'
+          items:
+            type: object
+            properties:
+              workspace:
+                $ref: 'workspace.yml#/components/schemas/workspace'
+              stix:
+                $ref: 'stix-common.yml#/components/schemas/stix-common'
+        deleted:
+          type: object
+          description: 'Summary of hard-deleted objects (if any).'
+          required:
+            - count
+            - stixIds
+          properties:
+            count:
+              type: integer
+              description: 'Number of hard-deleted objects.'
+              example: 0
+            stixIds:
+              type: array
+              description: 'STIX IDs of hard-deleted objects.'
+              items:
+                type: string
+              example: []

--- a/app/api/definitions/openapi.yml
+++ b/app/api/definitions/openapi.yml
@@ -95,6 +95,12 @@ paths:
   /api/techniques/{stixId}/modified/{modified}:
     $ref: 'paths/techniques-paths.yml#/paths/~1api~1techniques~1{stixId}~1modified~1{modified}'
 
+  /api/techniques/{stixId}/convert-to-subtechnique:
+    $ref: 'paths/techniques-paths.yml#/paths/~1api~1techniques~1{stixId}~1convert-to-subtechnique'
+
+  /api/techniques/{stixId}/convert-to-technique:
+    $ref: 'paths/techniques-paths.yml#/paths/~1api~1techniques~1{stixId}~1convert-to-technique'
+
   /api/techniques/{stixId}/revoke:
     $ref: 'paths/techniques-paths.yml#/paths/~1api~1techniques~1{stixId}~1revoke'
 

--- a/app/api/definitions/paths/techniques-paths.yml
+++ b/app/api/definitions/paths/techniques-paths.yml
@@ -367,6 +367,88 @@ paths:
         '404':
           description: 'A technique with the requested STIX id and modified date was not found.'
 
+  /api/techniques/{stixId}/convert-to-subtechnique:
+    post:
+      summary: 'Convert a technique to a subtechnique'
+      operationId: 'technique-convert-to-subtechnique'
+      description: |
+        Converts the technique identified by the stixId path parameter into a subtechnique
+        of the specified parent technique. This operation:
+        - Generates a new subtechnique-format ATT&CK ID (e.g., T1234.001)
+        - Sets `x_mitre_is_subtechnique` to `true`
+        - Rebuilds the ATT&CK external reference with the new ID and URL
+        - Persists the result as a new version of the object
+
+        The technique must not already be a subtechnique or revoked.
+      tags:
+        - 'Techniques'
+      parameters:
+        - name: stixId
+          in: path
+          description: 'STIX id of the technique to convert'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - parentTechniqueAttackId
+              properties:
+                parentTechniqueAttackId:
+                  type: string
+                  pattern: '^T\d{4}$'
+                  description: 'ATT&CK ID of the parent technique (e.g., T1234)'
+                  example: 'T1234'
+      responses:
+        '200':
+          description: 'The technique was successfully converted to a subtechnique.'
+          content:
+            application/json:
+              schema:
+                $ref: '../components/techniques.yml#/components/schemas/technique'
+        '400':
+          description: 'Invalid request. The technique is already a subtechnique, is revoked, or the parent ID is invalid.'
+        '404':
+          description: 'The technique was not found.'
+
+  /api/techniques/{stixId}/convert-to-technique:
+    post:
+      summary: 'Convert a subtechnique to a technique'
+      operationId: 'technique-convert-to-technique'
+      description: |
+        Converts the subtechnique identified by the stixId path parameter into a top-level technique.
+        This operation:
+        - Generates a new technique-format ATT&CK ID (e.g., T1235)
+        - Sets `x_mitre_is_subtechnique` to `false`
+        - Rebuilds the ATT&CK external reference with the new ID and URL
+        - Persists the result as a new version of the object
+
+        The technique must currently be a subtechnique and must not be revoked.
+      tags:
+        - 'Techniques'
+      parameters:
+        - name: stixId
+          in: path
+          description: 'STIX id of the subtechnique to convert'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'The subtechnique was successfully converted to a technique.'
+          content:
+            application/json:
+              schema:
+                $ref: '../components/techniques.yml#/components/schemas/technique'
+        '400':
+          description: 'Invalid request. The object is not a subtechnique or is revoked.'
+        '404':
+          description: 'The technique was not found.'
+
   /api/techniques/{stixId}/revoke:
     post:
       summary: 'Revoke a technique'

--- a/app/api/definitions/paths/techniques-paths.yml
+++ b/app/api/definitions/paths/techniques-paths.yml
@@ -409,9 +409,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '../components/techniques.yml#/components/schemas/technique'
+                $ref: '../components/workflow-response.yml#/components/schemas/workflow-response'
         '400':
-          description: 'Invalid request. The technique is already a subtechnique, is revoked, or the parent ID is invalid.'
+          description: 'Invalid request. The technique is already a subtechnique, is revoked, or the parent technique does not exist.'
         '404':
           description: 'The technique was not found.'
 
@@ -425,6 +425,7 @@ paths:
         - Generates a new technique-format ATT&CK ID (e.g., T1235)
         - Sets `x_mitre_is_subtechnique` to `false`
         - Rebuilds the ATT&CK external reference with the new ID and URL
+        - Deprecates any existing subtechnique-of relationships
         - Persists the result as a new version of the object
 
         The technique must currently be a subtechnique and must not be revoked.
@@ -443,7 +444,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '../components/techniques.yml#/components/schemas/technique'
+                $ref: '../components/workflow-response.yml#/components/schemas/workflow-response'
         '400':
           description: 'Invalid request. The object is not a subtechnique or is revoked.'
         '404':
@@ -456,6 +457,7 @@ paths:
       description: |
         Revokes the technique identified by the stixId path parameter in favor of the revoking object specified in the request body.
         Optionally transfers relationships from the revoked object to the revoking object.
+        Deprecates all relationships referencing the revoked object.
       tags:
         - 'Techniques'
       parameters:
@@ -467,7 +469,7 @@ paths:
             type: string
         - name: preserveRelationships
           in: query
-          description: 'If true, relationships referencing the revoked object are cloned to point to the revoking object before deletion.'
+          description: 'If true, relationships referencing the revoked object are cloned to point to the revoking object before deprecation.'
           schema:
             type: boolean
             default: false
@@ -495,6 +497,10 @@ paths:
       responses:
         '200':
           description: 'The technique was successfully revoked.'
+          content:
+            application/json:
+              schema:
+                $ref: '../components/workflow-response.yml#/components/schemas/workflow-response'
         '400':
           description: 'Missing or invalid parameters.'
         '404':

--- a/app/controllers/techniques-controller.js
+++ b/app/controllers/techniques-controller.js
@@ -190,6 +190,36 @@ exports.revoke = async function (req, res, next) {
   }
 };
 
+exports.convertToSubtechnique = async function (req, res, next) {
+  try {
+    const options = {
+      userAccountId: req.user?.userAccountId,
+    };
+    const result = await techniquesService.convertToSubtechnique(
+      req.params.stixId,
+      req.body,
+      options,
+    );
+    logger.debug('Success: Converted technique to subtechnique ' + result.stix.id);
+    return res.status(200).send(result);
+  } catch (err) {
+    return next(err);
+  }
+};
+
+exports.convertToTechnique = async function (req, res, next) {
+  try {
+    const options = {
+      userAccountId: req.user?.userAccountId,
+    };
+    const result = await techniquesService.convertToTechnique(req.params.stixId, options);
+    logger.debug('Success: Converted subtechnique to technique ' + result.stix.id);
+    return res.status(200).send(result);
+  } catch (err) {
+    return next(err);
+  }
+};
+
 exports.retrieveTacticsForTechnique = async function (req, res) {
   try {
     const options = {

--- a/app/controllers/techniques-controller.js
+++ b/app/controllers/techniques-controller.js
@@ -200,7 +200,7 @@ exports.convertToSubtechnique = async function (req, res, next) {
       req.body,
       options,
     );
-    logger.debug('Success: Converted technique to subtechnique ' + result.stix.id);
+    logger.debug('Success: Converted technique to subtechnique ' + result.primary?.stix?.id);
     return res.status(200).send(result);
   } catch (err) {
     return next(err);
@@ -213,7 +213,7 @@ exports.convertToTechnique = async function (req, res, next) {
       userAccountId: req.user?.userAccountId,
     };
     const result = await techniquesService.convertToTechnique(req.params.stixId, options);
-    logger.debug('Success: Converted subtechnique to technique ' + result.stix.id);
+    logger.debug('Success: Converted subtechnique to technique ' + result.primary?.stix?.id);
     return res.status(200).send(result);
   } catch (err) {
     return next(err);

--- a/app/lib/event-bus.js
+++ b/app/lib/event-bus.js
@@ -62,8 +62,9 @@ class EventBus extends EventEmitter {
         try {
           const listenerName = listener.name || 'anonymous';
           logger.debug(`EventBus: Executing listener '${listenerName}' for '${eventName}'`);
-          await listener(payload);
+          const result = await listener(payload);
           logger.debug(`EventBus: Listener '${listenerName}' completed successfully`);
+          return result;
         } catch (error) {
           const listenerName = listener.name || 'anonymous';
           logger.error(`EventBus: Listener '${listenerName}' failed for '${eventName}':`, error);
@@ -79,6 +80,9 @@ class EventBus extends EventEmitter {
         `EventBus: ${failures.length}/${listeners.length} listeners failed for '${eventName}'`,
       );
     }
+
+    // Return fulfilled handler results for callers that need them (e.g., WorkflowResult)
+    return results.filter((r) => r.status === 'fulfilled' && r.value != null).map((r) => r.value);
   }
 
   /**

--- a/app/lib/workflow-result.js
+++ b/app/lib/workflow-result.js
@@ -1,0 +1,162 @@
+'use strict';
+
+/**
+ * DTO builder for universal workflow endpoint responses.
+ *
+ * All workflow endpoints (revoke, convert-to-subtechnique, convert-to-technique)
+ * return a WorkflowResult so that the caller has full visibility into every
+ * object that was created, modified, deprecated, or deleted as a consequence
+ * of their request.
+ *
+ * @see docs/developer/workflow-response-pattern.md
+ */
+class WorkflowResult {
+  /**
+   * @param {string} workflowName - Discriminator string (e.g., 'revoke', 'convert-to-subtechnique')
+   */
+  constructor(workflowName) {
+    this.workflow = workflowName;
+    this.primary = null;
+    this.sideEffects = {
+      created: [],
+      modified: [],
+      deprecated: [],
+      deleted: { count: 0, stixIds: [] },
+    };
+    this.warnings = [];
+  }
+
+  /**
+   * Set the primary object that the user acted on.
+   * @param {Object} document - Full workspace+stix document (Mongoose doc or plain object)
+   */
+  setPrimary(document) {
+    this.primary = document;
+  }
+
+  /**
+   * Add one or more documents to the created side-effects list.
+   * @param {Object|Array<Object>} docOrDocs - Document(s) created as a consequence
+   */
+  addCreated(docOrDocs) {
+    this._pushDocs(this.sideEffects.created, docOrDocs);
+  }
+
+  /**
+   * Add one or more documents to the modified side-effects list.
+   * @param {Object|Array<Object>} docOrDocs - Document(s) modified as a consequence
+   */
+  addModified(docOrDocs) {
+    this._pushDocs(this.sideEffects.modified, docOrDocs);
+  }
+
+  /**
+   * Add one or more documents to the deprecated side-effects list.
+   * @param {Object|Array<Object>} docOrDocs - Document(s) deprecated as a consequence
+   */
+  addDeprecated(docOrDocs) {
+    this._pushDocs(this.sideEffects.deprecated, docOrDocs);
+  }
+
+  /**
+   * Record hard-deleted documents by their STIX IDs.
+   * @param {Array<string>} stixIds - STIX IDs of deleted documents
+   */
+  addDeleted(stixIds) {
+    if (!Array.isArray(stixIds)) return;
+    this.sideEffects.deleted.stixIds.push(...stixIds);
+    this.sideEffects.deleted.count = this.sideEffects.deleted.stixIds.length;
+  }
+
+  /**
+   * Add a single warning message.
+   * @param {string} message
+   */
+  addWarning(message) {
+    this.warnings.push(message);
+  }
+
+  /**
+   * Add multiple warning messages.
+   * @param {Array<string>} messages
+   */
+  addWarnings(messages) {
+    if (!Array.isArray(messages)) return;
+    this.warnings.push(...messages);
+  }
+
+  /**
+   * Merge results returned by EventBus.emit() into this WorkflowResult.
+   *
+   * Each element in eventResults is an object returned by an event handler
+   * with any subset of: { created, modified, deprecated, warnings }.
+   *
+   * @param {Array<Object>} eventResults - Array of handler return values
+   */
+  mergeEventResults(eventResults) {
+    if (!Array.isArray(eventResults)) return;
+    for (const handlerResult of eventResults) {
+      if (!handlerResult || typeof handlerResult !== 'object') continue;
+      if (handlerResult.created) this.addCreated(handlerResult.created);
+      if (handlerResult.modified) this.addModified(handlerResult.modified);
+      if (handlerResult.deprecated) this.addDeprecated(handlerResult.deprecated);
+      if (handlerResult.warnings) this.addWarnings(handlerResult.warnings);
+    }
+  }
+
+  /**
+   * Serialize to a plain JSON-safe object.
+   *
+   * Calls .toObject() on any Mongoose documents and strips internal fields
+   * (_id, __v, __t) from all documents.
+   *
+   * @returns {Object} Plain object suitable for res.json()
+   */
+  toJSON() {
+    return {
+      workflow: this.workflow,
+      primary: WorkflowResult._toPlain(this.primary),
+      sideEffects: {
+        created: this.sideEffects.created.map(WorkflowResult._toPlain),
+        modified: this.sideEffects.modified.map(WorkflowResult._toPlain),
+        deprecated: this.sideEffects.deprecated.map(WorkflowResult._toPlain),
+        deleted: { ...this.sideEffects.deleted },
+      },
+      warnings: [...this.warnings],
+    };
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────
+
+  /**
+   * Push one or more documents into an array.
+   * @param {Array} target
+   * @param {Object|Array<Object>} docOrDocs
+   * @private
+   */
+  _pushDocs(target, docOrDocs) {
+    if (Array.isArray(docOrDocs)) {
+      target.push(...docOrDocs);
+    } else if (docOrDocs) {
+      target.push(docOrDocs);
+    }
+  }
+
+  /**
+   * Convert a Mongoose document (or plain object) to a clean plain object.
+   * Strips _id, __v, __t which are internal Mongoose/MongoDB fields.
+   * @param {Object} doc
+   * @returns {Object}
+   * @private
+   */
+  static _toPlain(doc) {
+    if (!doc) return doc;
+    const plain = typeof doc.toObject === 'function' ? doc.toObject() : { ...doc };
+    delete plain._id;
+    delete plain.__v;
+    delete plain.__t;
+    return plain;
+  }
+}
+
+module.exports = WorkflowResult;

--- a/app/repository/_base.repository.js
+++ b/app/repository/_base.repository.js
@@ -202,6 +202,23 @@ class BaseRepository extends AbstractRepository {
     }
   }
 
+  /**
+   * Retrieve the latest version of an object by its ATT&CK ID (e.g., "T1234", "G0001").
+   *
+   * @param {string} attackId - The workspace ATT&CK ID to look up
+   * @returns {Promise<Object|null>} The latest object version, or null if not found
+   */
+  async retrieveLatestByAttackId(attackId) {
+    try {
+      return await this.model
+        .findOne({ 'workspace.attack_id': attackId })
+        .sort('-stix.modified')
+        .exec();
+    } catch (err) {
+      throw new DatabaseError(err);
+    }
+  }
+
   async retrieveLatestByStixIdLean(stixId) {
     try {
       return await this.model

--- a/app/routes/techniques-routes.js
+++ b/app/routes/techniques-routes.js
@@ -45,6 +45,22 @@ router
   .post(authn.authenticate, authz.requireRole(authz.editorOrHigher), techniquesController.revoke);
 
 router
+  .route('/techniques/:stixId/convert-to-subtechnique')
+  .post(
+    authn.authenticate,
+    authz.requireRole(authz.editorOrHigher),
+    techniquesController.convertToSubtechnique,
+  );
+
+router
+  .route('/techniques/:stixId/convert-to-technique')
+  .post(
+    authn.authenticate,
+    authz.requireRole(authz.editorOrHigher),
+    techniquesController.convertToTechnique,
+  );
+
+router
   .route('/techniques/:stixId/modified/:modified/tactics')
   .get(
     authn.authenticate,

--- a/app/services/meta-classes/base.service.js
+++ b/app/services/meta-classes/base.service.js
@@ -691,6 +691,12 @@ class BaseService extends ServiceWithHooks {
     // Compose server-controlled fields from existing document
     data.stix.x_mitre_attack_spec_version = document.stix.x_mitre_attack_spec_version;
 
+    // Preserve x_mitre_is_subtechnique — changing subtechnique status requires
+    // the dedicated conversion endpoints, not the generic update path.
+    if (document.stix.x_mitre_is_subtechnique !== undefined) {
+      data.stix.x_mitre_is_subtechnique = document.stix.x_mitre_is_subtechnique;
+    }
+
     if (document.workspace?.attack_id) {
       data.workspace = data.workspace || {};
       data.workspace.attack_id = document.workspace.attack_id;

--- a/app/services/meta-classes/base.service.js
+++ b/app/services/meta-classes/base.service.js
@@ -953,6 +953,9 @@ class BaseService extends ServiceWithHooks {
             logger.info(
               `Skipping duplicate relationship transfer: ${candidateTriple} already exists on Object B`,
             );
+            result.addWarning(
+              `Skipping duplicate relationship transfer: ${candidateTriple} already exists on Object B`,
+            );
             continue;
           }
 

--- a/app/services/meta-classes/base.service.js
+++ b/app/services/meta-classes/base.service.js
@@ -24,6 +24,7 @@ const {
 } = require('../../exceptions');
 const { getSchema, processValidationIssues } = require('../system/validate-service');
 const ServiceWithHooks = require('./hooks.service');
+const WorkflowResult = require('../../lib/workflow-result');
 
 // Import required repositories
 const systemConfigurationRepository = require('../../repository/system-configurations-repository');
@@ -870,9 +871,15 @@ class BaseService extends ServiceWithHooks {
 
     const revokedDocument = await this.repository.save(objectAData);
 
+    const result = new WorkflowResult('revoke');
+    result.setPrimary(revokedDocument);
+
     // ──────────────────────────────────────────────
     // 5. CREATE REVOKED-BY RELATIONSHIP
     // ──────────────────────────────────────────────
+    // NOTE: This is a direct cross-service write (BaseService → RelationshipsService.create).
+    // The revoke workflow predates the event-driven architecture and is shared by all SDO types.
+    // TODO: Migrate to an event-driven pattern for consistency with the conversion workflows.
     const now = new Date().toISOString();
     const revokedByRelationship = await relationshipsService.create(
       {
@@ -891,6 +898,7 @@ class BaseService extends ServiceWithHooks {
       },
       { userAccountId: options.userAccountId },
     );
+    result.addCreated(revokedByRelationship);
 
     // TODO what if relationshipsService.create fails after we've already marked Object A as revoked?
     // We should have error handling to attempt to roll back the revoked status if the relationship
@@ -900,10 +908,8 @@ class BaseService extends ServiceWithHooks {
     // We would also need to handle potential errors in that rollback attempt and log them appropriately.
 
     // ──────────────────────────────────────────────
-    // 6. HANDLE RELATIONSHIPS
+    // 6. HANDLE RELATIONSHIPS (transfer if preserveRelationships is set)
     // ──────────────────────────────────────────────
-    const relationshipsSummary = { deleted: 0, transferred: 0, warnings: [] };
-
     const existingRelationships = await relationshipsRepository.retrieveAllBySourceOrTarget(
       objectA.stix.id,
     );
@@ -944,8 +950,6 @@ class BaseService extends ServiceWithHooks {
           // Skip if Object B already has an equivalent relationship
           const candidateTriple = `${relData.stix.source_ref}--${relData.stix.relationship_type}--${relData.stix.target_ref}`;
           if (objectBRelTriples.has(candidateTriple)) {
-            relationshipsSummary.duplicatesSkipped =
-              (relationshipsSummary.duplicatesSkipped || 0) + 1;
             logger.info(
               `Skipping duplicate relationship transfer: ${candidateTriple} already exists on Object B`,
             );
@@ -955,18 +959,16 @@ class BaseService extends ServiceWithHooks {
           // Generate a new STIX ID for the cloned relationship
           relData.stix.id = `relationship--${uuid.v4()}`;
 
-          await relationshipsService.create(relData, {
+          const transferredRel = await relationshipsService.create(relData, {
             userAccountId: options.userAccountId,
           });
-          relationshipsSummary.transferred++;
+          result.addCreated(transferredRel);
 
           // Track the newly created triple so subsequent iterations don't create duplicates
           objectBRelTriples.add(candidateTriple);
         } catch (err) {
           logger.warn(`Failed to transfer relationship ${rel.stix.id}: ${err.message}`);
-          relationshipsSummary.warnings.push(
-            `Failed to transfer relationship ${rel.stix.id}: ${err.message}`,
-          );
+          result.addWarning(`Failed to transfer relationship ${rel.stix.id}: ${err.message}`);
         }
       }
     }
@@ -982,27 +984,17 @@ class BaseService extends ServiceWithHooks {
     // RelationshipsService listens for revoked events and deprecates all relationships
     // referencing the revoked object (except those in excludeRelationshipIds).
     // EventBus.emit() awaits all listeners, so deprecation completes before we return.
+    // Handler results (deprecated docs, warnings) are merged into the WorkflowResult.
     const excludeRelationshipIds = [revokedByRelationship.stix.id];
-    await this.emitRevokedEvent(revokedDocument, objectB, options, { excludeRelationshipIds });
-
-    // Count deprecated relationships via cross-service READ (allowed by architecture)
-    const postRevokeRelationships = await relationshipsRepository.retrieveAllBySourceOrTarget(
-      objectA.stix.id,
-    );
-    relationshipsSummary.deprecated = postRevokeRelationships.filter(
-      (r) => r.stix.x_mitre_deprecated === true && r.stix.id !== revokedByRelationship.stix.id,
-    ).length;
+    const eventResults = await this.emitRevokedEvent(revokedDocument, objectB, options, {
+      excludeRelationshipIds,
+    });
+    result.mergeEventResults(eventResults);
 
     // ──────────────────────────────────────────────
     // 9. RETURN RESULT
     // ──────────────────────────────────────────────
-    return {
-      revokedObject: revokedDocument,
-      revokedByRelationship: revokedByRelationship.toObject
-        ? revokedByRelationship.toObject()
-        : revokedByRelationship,
-      relationshipsSummary,
-    };
+    return result.toJSON();
   }
 
   // TODO rename to deleteManyByStixId

--- a/app/services/meta-classes/hooks.service.js
+++ b/app/services/meta-classes/hooks.service.js
@@ -175,7 +175,7 @@ class ServiceWithHooks {
 
     logger.info(`Emitting event '${eventName}' for ${revokedDocument.stix.id}`);
 
-    await EventBus.emit(eventName, {
+    const results = await EventBus.emit(eventName, {
       stixId: revokedDocument.stix.id,
       revokedDocument: revokedDocument.toObject ? revokedDocument.toObject() : revokedDocument,
       revokingDocument: revokingDocument.toObject ? revokingDocument.toObject() : revokingDocument,
@@ -185,6 +185,7 @@ class ServiceWithHooks {
     });
 
     logger.info(`Event '${eventName}' emission complete`);
+    return results;
   }
 }
 

--- a/app/services/stix/relationships-service.js
+++ b/app/services/stix/relationships-service.js
@@ -47,11 +47,70 @@ class RelationshipsService extends BaseService {
     }
 
     EventBus.on(
+      EventConstants.TECHNIQUE_CONVERTED_TO_SUBTECHNIQUE,
+      this.handleTechniqueConvertedToSubtechnique.bind(this),
+    );
+
+    EventBus.on(
       EventConstants.SUBTECHNIQUE_CONVERTED_TO_TECHNIQUE,
-      RelationshipsService.handleSubtechniqueConvertedToTechnique.bind(RelationshipsService),
+      this.handleSubtechniqueConvertedToTechnique.bind(this),
     );
 
     logger.info('RelationshipsService: Event listeners initialized');
+  }
+
+  /**
+   * Create a subtechnique-of SRO when a technique is converted to a subtechnique.
+   *
+   * Uses the service instance's create() method (via module.exports singleton)
+   * so that the relationship gets a proper stix.id, server-controlled fields,
+   * and ADM validation — the same path as any user-created relationship.
+   *
+   * @param {Object} payload - Event payload
+   * @param {string} payload.stixId - STIX ID of the converted subtechnique
+   * @param {string} payload.parentStixId - STIX ID of the parent technique
+   * @param {string} [payload.userAccountId] - Authenticated user's account ID
+   */
+  static async handleTechniqueConvertedToSubtechnique(payload) {
+    const { stixId, parentStixId, userAccountId } = payload;
+
+    logger.info(
+      `RelationshipsService: Creating subtechnique-of relationship for ${stixId} -> ${parentStixId}`,
+    );
+
+    try {
+      // Use the singleton instance exported by this module
+      const relationshipsService = module.exports;
+      const now = new Date().toISOString();
+      const createdRelationship = await relationshipsService.create(
+        {
+          workspace: {
+            workflow: { state: 'reviewed' }, // TODO introduce a new workflow state for entities that are never reviewed by users; for now, set to 'reviewed' to ensure they undergo full ADM validation
+          },
+          stix: {
+            type: 'relationship',
+            spec_version: '2.1',
+            relationship_type: 'subtechnique-of',
+            source_ref: stixId,
+            target_ref: parentStixId,
+            created: now,
+            modified: now,
+          },
+        },
+        { userAccountId },
+      );
+
+      logger.info(
+        `RelationshipsService: Created subtechnique-of relationship for ${stixId} -> ${parentStixId}`,
+      );
+
+      return { created: [createdRelationship] };
+    } catch (error) {
+      logger.error(
+        `RelationshipsService: Error creating subtechnique-of relationship for ${stixId}: ${error.message}`,
+      );
+      return { warnings: [`Failed to create subtechnique-of relationship for ${stixId}`] };
+    }
   }
 
   /**
@@ -68,6 +127,9 @@ class RelationshipsService extends BaseService {
 
     logger.info(`RelationshipsService: Deprecating subtechnique-of relationships for ${stixId}`);
 
+    const deprecatedDocs = [];
+    const warnings = [];
+
     try {
       const subtechniqueOfRels = await relationshipsRepository.retrieveAll({
         sourceRef: stixId,
@@ -77,7 +139,6 @@ class RelationshipsService extends BaseService {
         includeDeprecated: false,
       });
 
-      let deprecatedCount = 0;
       for (const rel of subtechniqueOfRels) {
         try {
           const deprecatedVersion = rel.toObject ? rel.toObject() : { ...rel };
@@ -88,24 +149,28 @@ class RelationshipsService extends BaseService {
           deprecatedVersion.stix.x_mitre_deprecated = true;
           deprecatedVersion.stix.modified = new Date().toISOString();
 
-          await relationshipsRepository.save(deprecatedVersion);
-          deprecatedCount++;
+          const saved = await relationshipsRepository.save(deprecatedVersion);
+          deprecatedDocs.push(saved);
         } catch (error) {
           logger.error(
             `RelationshipsService: Error deprecating relationship ${rel.stix?.id}: ${error.message}`,
           );
+          warnings.push(`Failed to deprecate relationship ${rel.stix?.id}`);
         }
       }
 
       logger.info(
-        `RelationshipsService: Deprecated ${deprecatedCount}/${subtechniqueOfRels.length} subtechnique-of relationship(s) for ${stixId}`,
+        `RelationshipsService: Deprecated ${deprecatedDocs.length}/${subtechniqueOfRels.length} subtechnique-of relationship(s) for ${stixId}`,
       );
     } catch (error) {
       logger.error(
         `RelationshipsService: Error handling subtechnique-to-technique conversion for ${stixId}:`,
         error,
       );
+      warnings.push(`Failed to deprecate subtechnique-of relationships for ${stixId}`);
     }
+
+    return { deprecated: deprecatedDocs, warnings };
   }
 
   /**
@@ -121,37 +186,47 @@ class RelationshipsService extends BaseService {
 
     logger.info(`RelationshipsService heard event: object revoked for ${stixId}`);
 
-    const relationships = await relationshipsRepository.retrieveAllBySourceOrTarget(stixId);
+    const deprecatedDocs = [];
+    const warnings = [];
 
-    const toDeprecate = relationships.filter(
-      (rel) => !excludeRelationshipIds.includes(rel.stix.id),
-    );
+    try {
+      const relationships = await relationshipsRepository.retrieveAllBySourceOrTarget(stixId);
 
-    let deprecatedCount = 0;
-    for (const rel of toDeprecate) {
-      try {
-        const relData = rel.toObject ? rel.toObject() : { ...rel };
-        delete relData._id;
-        delete relData.__v;
-        delete relData.__t;
+      const toDeprecate = relationships.filter(
+        (rel) => !excludeRelationshipIds.includes(rel.stix.id),
+      );
 
-        relData.stix.x_mitre_deprecated = true;
-        relData.stix.modified = new Date().toISOString();
+      for (const rel of toDeprecate) {
+        try {
+          const relData = rel.toObject ? rel.toObject() : { ...rel };
+          delete relData._id;
+          delete relData.__v;
+          delete relData.__t;
 
-        await relationshipsRepository.save(relData);
-        deprecatedCount++;
+          relData.stix.x_mitre_deprecated = true;
+          relData.stix.modified = new Date().toISOString();
 
-        logger.info(
-          `Deprecated relationship ${rel.stix.id} (was referencing revoked object ${stixId})`,
-        );
-      } catch (error) {
-        logger.error(`Failed to deprecate relationship ${rel.stix.id}: ${error.message}`);
+          const saved = await relationshipsRepository.save(relData);
+          deprecatedDocs.push(saved);
+
+          logger.info(
+            `Deprecated relationship ${rel.stix.id} (was referencing revoked object ${stixId})`,
+          );
+        } catch (error) {
+          logger.error(`Failed to deprecate relationship ${rel.stix.id}: ${error.message}`);
+          warnings.push(`Failed to deprecate relationship ${rel.stix.id}`);
+        }
       }
+
+      logger.info(
+        `RelationshipsService: deprecated ${deprecatedDocs.length}/${toDeprecate.length} relationships for revoked object ${stixId}`,
+      );
+    } catch (error) {
+      logger.error(`RelationshipsService: Error handling object revoked for ${stixId}:`, error);
+      warnings.push(`Failed to deprecate relationships for revoked object ${stixId}`);
     }
 
-    logger.info(
-      `RelationshipsService: deprecated ${deprecatedCount}/${toDeprecate.length} relationships for revoked object ${stixId}`,
-    );
+    return { deprecated: deprecatedDocs, warnings };
   }
 
   async retrieveAll(options) {

--- a/app/services/stix/relationships-service.js
+++ b/app/services/stix/relationships-service.js
@@ -3,6 +3,9 @@
 const { BaseService } = require('../meta-classes');
 const relationshipsRepository = require('../../repository/relationships-repository');
 const { Relationship: RelationshipType } = require('../../lib/types');
+const EventBus = require('../../lib/event-bus');
+const EventConstants = require('../../lib/event-constants');
+const logger = require('../../lib/logger');
 
 // Map STIX types to ATT&CK types
 const objectTypeMap = new Map([
@@ -20,6 +23,73 @@ const objectTypeMap = new Map([
 ]);
 
 class RelationshipsService extends BaseService {
+  /**
+   * Initialize event listeners.
+   * Called once on module load.
+   */
+  static initializeEventListeners() {
+    EventBus.on(
+      EventConstants.SUBTECHNIQUE_CONVERTED_TO_TECHNIQUE,
+      RelationshipsService.handleSubtechniqueConvertedToTechnique.bind(RelationshipsService),
+    );
+
+    logger.info('RelationshipsService: Event listeners initialized');
+  }
+
+  /**
+   * Deprecate subtechnique-of SROs when a subtechnique is converted to a technique.
+   *
+   * Creates a new version of each active subtechnique-of relationship where
+   * source_ref = the converted object, setting x_mitre_deprecated = true.
+   *
+   * @param {Object} payload - Event payload
+   * @param {string} payload.stixId - STIX ID of the converted subtechnique
+   */
+  static async handleSubtechniqueConvertedToTechnique(payload) {
+    const { stixId } = payload;
+
+    logger.info(`RelationshipsService: Deprecating subtechnique-of relationships for ${stixId}`);
+
+    try {
+      const subtechniqueOfRels = await relationshipsRepository.retrieveAll({
+        sourceRef: stixId,
+        relationshipType: 'subtechnique-of',
+        versions: 'latest',
+        includeRevoked: false,
+        includeDeprecated: false,
+      });
+
+      let deprecatedCount = 0;
+      for (const rel of subtechniqueOfRels) {
+        try {
+          const deprecatedVersion = rel.toObject ? rel.toObject() : { ...rel };
+          delete deprecatedVersion._id;
+          delete deprecatedVersion.__v;
+          delete deprecatedVersion.__t;
+
+          deprecatedVersion.stix.x_mitre_deprecated = true;
+          deprecatedVersion.stix.modified = new Date().toISOString();
+
+          await relationshipsRepository.save(deprecatedVersion);
+          deprecatedCount++;
+        } catch (error) {
+          logger.error(
+            `RelationshipsService: Error deprecating relationship ${rel.stix?.id}: ${error.message}`,
+          );
+        }
+      }
+
+      logger.info(
+        `RelationshipsService: Deprecated ${deprecatedCount}/${subtechniqueOfRels.length} subtechnique-of relationship(s) for ${stixId}`,
+      );
+    } catch (error) {
+      logger.error(
+        `RelationshipsService: Error handling subtechnique-to-technique conversion for ${stixId}:`,
+        error,
+      );
+    }
+  }
+
   async retrieveAll(options) {
     let results = await this.repository.retrieveAll(options);
 
@@ -99,6 +169,8 @@ class RelationshipsService extends BaseService {
     }
   }
 }
+
+RelationshipsService.initializeEventListeners();
 
 // Default export
 module.exports.RelationshipsService = RelationshipsService;

--- a/app/services/stix/techniques-service.js
+++ b/app/services/stix/techniques-service.js
@@ -18,6 +18,7 @@ const {
 } = require('../../lib/external-reference-builder');
 const EventBus = require('../../lib/event-bus');
 const EventConstants = require('../../lib/event-constants');
+const WorkflowResult = require('../../lib/workflow-result');
 const logger = require('../../lib/logger');
 
 /**
@@ -217,6 +218,16 @@ class TechniquesService extends BaseService {
       });
     }
 
+    // Validate that the parent technique exists
+    const parentTechnique = await this.repository.retrieveLatestByAttackId(
+      data.parentTechniqueAttackId,
+    );
+    if (!parentTechnique) {
+      throw new BadRequestError({
+        details: `Parent technique with ATT&CK ID ${data.parentTechniqueAttackId} not found`,
+      });
+    }
+
     // Check if this technique has child subtechniques (via subtechnique-of SROs).
     // Cross-service READ is permitted per architecture guidelines.
     // If children exist, block the conversion — the user must rehome them first.
@@ -272,16 +283,18 @@ class TechniquesService extends BaseService {
       `Converted technique ${stixId} to subtechnique: ${technique.workspace?.attack_id} -> ${newAttackId}`,
     );
 
-    // Emit domain event for cross-service coordination
-    await EventBus.emit(EventConstants.TECHNIQUE_CONVERTED_TO_SUBTECHNIQUE, {
-      stixId,
-      document: savedDocument.toObject ? savedDocument.toObject() : savedDocument,
-      previousAttackId: technique.workspace?.attack_id,
-      newAttackId,
-      parentTechniqueAttackId: data.parentTechniqueAttackId,
-    });
+    const result = new WorkflowResult('convert-to-subtechnique');
+    result.setPrimary(savedDocument);
 
-    return savedDocument.toObject ? savedDocument.toObject() : savedDocument;
+    // Emit domain event — RelationshipsService listens to create the subtechnique-of SRO
+    const eventResults = await EventBus.emit(EventConstants.TECHNIQUE_CONVERTED_TO_SUBTECHNIQUE, {
+      stixId /** STIX ID of the converted subtechnique */,
+      parentStixId: parentTechnique.stix.id /** STIX ID of the parent technique */,
+      userAccountId: options.userAccountId,
+    });
+    result.mergeEventResults(eventResults);
+
+    return result.toJSON();
   }
 
   /**
@@ -352,15 +365,16 @@ class TechniquesService extends BaseService {
       `Converted subtechnique ${stixId} to technique: ${technique.workspace?.attack_id} -> ${newAttackId}`,
     );
 
-    // Emit domain event — RelationshipsService listens to deprecate subtechnique-of SROs
-    await EventBus.emit(EventConstants.SUBTECHNIQUE_CONVERTED_TO_TECHNIQUE, {
-      stixId,
-      document: savedDocument.toObject ? savedDocument.toObject() : savedDocument,
-      previousAttackId: technique.workspace?.attack_id,
-      newAttackId,
-    });
+    const result = new WorkflowResult('convert-to-technique');
+    result.setPrimary(savedDocument);
 
-    return savedDocument.toObject ? savedDocument.toObject() : savedDocument;
+    // Emit domain event — RelationshipsService listens to deprecate subtechnique-of SROs
+    const eventResults = await EventBus.emit(EventConstants.SUBTECHNIQUE_CONVERTED_TO_TECHNIQUE, {
+      stixId /** STIX ID of the converted subtechnique */,
+    });
+    result.mergeEventResults(eventResults);
+
+    return result.toJSON();
   }
 
   async retrieveTacticsForTechnique(stixId, modified, options) {

--- a/app/services/stix/techniques-service.js
+++ b/app/services/stix/techniques-service.js
@@ -5,7 +5,17 @@ const { BaseService } = require('../meta-classes');
 const techniquesRepository = require('../../repository/techniques-repository');
 
 const { Technique: TechniqueType } = require('../../lib/types');
-const { BadlyFormattedParameterError, MissingParameterError } = require('../../exceptions');
+const {
+  BadlyFormattedParameterError,
+  BadRequestError,
+  MissingParameterError,
+  NotFoundError,
+} = require('../../exceptions');
+const attackIdGenerator = require('../../lib/attack-id-generator');
+const {
+  buildAttackExternalReference,
+  removeAttackExternalReferences,
+} = require('../../lib/external-reference-builder');
 const EventBus = require('../../lib/event-bus');
 const EventConstants = require('../../lib/event-constants');
 const logger = require('../../lib/logger');
@@ -156,6 +166,201 @@ class TechniquesService extends BaseService {
       options.limit === 0 ? data.length : Math.min(options.offset + options.limit, data.length);
 
     return data.slice(startPos, endPos);
+  }
+
+  // ============================
+  // Subtechnique Conversion
+  // ============================
+
+  /**
+   * Convert a technique to a subtechnique.
+   *
+   * Generates a new subtechnique-format ATT&CK ID (e.g., T1234.001) under the
+   * specified parent, updates x_mitre_is_subtechnique, rebuilds the ATT&CK
+   * external reference, and persists the result as a new version.
+   *
+   * @param {string} stixId - STIX ID of the technique to convert
+   * @param {Object} data - Request body
+   * @param {string} data.parentTechniqueAttackId - Parent technique ATT&CK ID (e.g., T1234)
+   * @param {Object} [options] - Options
+   * @param {string} [options.userAccountId] - Authenticated user's account ID
+   * @returns {Object} The newly created subtechnique version
+   */
+  async convertToSubtechnique(stixId, data, options = {}) {
+    // Lazy-load to avoid circular dependency
+    const relationshipsRepository = require('../../repository/relationships-repository');
+
+    if (!stixId) {
+      throw new MissingParameterError('stixId');
+    }
+    if (!data?.parentTechniqueAttackId) {
+      throw new MissingParameterError('parentTechniqueAttackId');
+    }
+    if (!/^T\d{4}$/.test(data.parentTechniqueAttackId)) {
+      throw new BadRequestError({
+        details: `Invalid parent technique ATT&CK ID format: ${data.parentTechniqueAttackId}. Must be T####.`,
+      });
+    }
+
+    const technique = await this.repository.retrieveLatestByStixId(stixId);
+    if (!technique) {
+      throw new NotFoundError({ details: `Technique with stixId ${stixId} not found` });
+    }
+    if (technique.stix.x_mitre_is_subtechnique === true) {
+      throw new BadRequestError({
+        details: `Technique ${stixId} is already a subtechnique`,
+      });
+    }
+    if (technique.stix.revoked === true) {
+      throw new BadRequestError({
+        details: `Cannot convert a revoked technique`,
+      });
+    }
+
+    // Check if this technique has child subtechniques (via subtechnique-of SROs).
+    // Cross-service READ is permitted per architecture guidelines.
+    // If children exist, block the conversion — the user must rehome them first.
+    const childRelationships = await relationshipsRepository.retrieveAll({
+      targetRef: stixId,
+      relationshipType: 'subtechnique-of',
+      versions: 'latest',
+      includeRevoked: false,
+      includeDeprecated: false,
+    });
+    if (childRelationships.length > 0) {
+      throw new BadRequestError({
+        details:
+          `Technique ${stixId} has ${childRelationships.length} subtechnique(s). ` +
+          `Rehome or remove the subtechnique-of relationships before converting this technique to a subtechnique.`,
+      });
+    }
+
+    // Generate new subtechnique ATT&CK ID
+    const newAttackId = await attackIdGenerator.generateAttackId(
+      'attack-pattern',
+      this.repository,
+      true,
+      data.parentTechniqueAttackId,
+    );
+
+    // Build new version
+    const newVersion = technique.toObject ? technique.toObject() : { ...technique };
+    delete newVersion._id;
+    delete newVersion.__v;
+    delete newVersion.__t;
+
+    newVersion.stix.x_mitre_is_subtechnique = true;
+    newVersion.stix.modified = new Date().toISOString();
+    newVersion.workspace = newVersion.workspace || {};
+    newVersion.workspace.attack_id = newAttackId;
+
+    // Rebuild external references: replace ATT&CK ref with the new one
+    const userRefs = removeAttackExternalReferences(newVersion.stix.external_references);
+    const newAttackRef = buildAttackExternalReference(newAttackId, 'attack-pattern', {
+      isSubtechnique: true,
+    });
+    newVersion.stix.external_references = newAttackRef ? [newAttackRef, ...userRefs] : userRefs;
+
+    if (options.userAccountId) {
+      newVersion.workspace.workflow = newVersion.workspace.workflow || {};
+      newVersion.workspace.workflow.created_by_user_account = options.userAccountId;
+    }
+
+    const savedDocument = await this.repository.save(newVersion);
+
+    logger.info(
+      `Converted technique ${stixId} to subtechnique: ${technique.workspace?.attack_id} -> ${newAttackId}`,
+    );
+
+    // Emit domain event for cross-service coordination
+    await EventBus.emit(EventConstants.TECHNIQUE_CONVERTED_TO_SUBTECHNIQUE, {
+      stixId,
+      document: savedDocument.toObject ? savedDocument.toObject() : savedDocument,
+      previousAttackId: technique.workspace?.attack_id,
+      newAttackId,
+      parentTechniqueAttackId: data.parentTechniqueAttackId,
+    });
+
+    return savedDocument.toObject ? savedDocument.toObject() : savedDocument;
+  }
+
+  /**
+   * Convert a subtechnique to a technique.
+   *
+   * Generates a new technique-format ATT&CK ID (e.g., T1235), updates
+   * x_mitre_is_subtechnique, rebuilds the ATT&CK external reference, and
+   * persists the result as a new version.
+   *
+   * @param {string} stixId - STIX ID of the subtechnique to convert
+   * @param {Object} [options] - Options
+   * @param {string} [options.userAccountId] - Authenticated user's account ID
+   * @returns {Object} The newly created technique version
+   */
+  async convertToTechnique(stixId, options = {}) {
+    if (!stixId) {
+      throw new MissingParameterError('stixId');
+    }
+
+    const technique = await this.repository.retrieveLatestByStixId(stixId);
+    if (!technique) {
+      throw new NotFoundError({ details: `Technique with stixId ${stixId} not found` });
+    }
+    if (technique.stix.x_mitre_is_subtechnique !== true) {
+      throw new BadRequestError({
+        details: `Technique ${stixId} is not a subtechnique`,
+      });
+    }
+    if (technique.stix.revoked === true) {
+      throw new BadRequestError({
+        details: `Cannot convert a revoked technique`,
+      });
+    }
+
+    // Generate new technique ATT&CK ID
+    const newAttackId = await attackIdGenerator.generateAttackId(
+      'attack-pattern',
+      this.repository,
+      false,
+    );
+
+    // Build new version
+    const newVersion = technique.toObject ? technique.toObject() : { ...technique };
+    delete newVersion._id;
+    delete newVersion.__v;
+    delete newVersion.__t;
+
+    newVersion.stix.x_mitre_is_subtechnique = false;
+    newVersion.stix.modified = new Date().toISOString();
+    newVersion.workspace = newVersion.workspace || {};
+    newVersion.workspace.attack_id = newAttackId;
+
+    // Rebuild external references: replace ATT&CK ref with the new one
+    const userRefs = removeAttackExternalReferences(newVersion.stix.external_references);
+    const newAttackRef = buildAttackExternalReference(newAttackId, 'attack-pattern', {
+      isSubtechnique: false,
+    });
+    newVersion.stix.external_references = newAttackRef ? [newAttackRef, ...userRefs] : userRefs;
+
+    if (options.userAccountId) {
+      newVersion.workspace.workflow = newVersion.workspace.workflow || {};
+      newVersion.workspace.workflow.created_by_user_account = options.userAccountId;
+    }
+
+    const savedDocument = await this.repository.save(newVersion);
+
+    logger.info(
+      `Converted subtechnique ${stixId} to technique: ${technique.workspace?.attack_id} -> ${newAttackId}`,
+    );
+
+    // Emit domain event — RelationshipsService listens to deprecate subtechnique-of SROs
+    await EventBus.emit(EventConstants.SUBTECHNIQUE_CONVERTED_TO_TECHNIQUE, {
+      stixId,
+      document: savedDocument.toObject ? savedDocument.toObject() : savedDocument,
+      previousAttackId: technique.workspace?.attack_id,
+      newAttackId,
+    });
+
+    return savedDocument.toObject ? savedDocument.toObject() : savedDocument;
   }
 
   async retrieveTacticsForTechnique(stixId, modified, options) {

--- a/app/tests/api/techniques/techniques.convert.spec.js
+++ b/app/tests/api/techniques/techniques.convert.spec.js
@@ -1,0 +1,518 @@
+const request = require('supertest');
+const { expect } = require('expect');
+
+const database = require('../../../lib/database-in-memory');
+const databaseConfiguration = require('../../../lib/database-configuration');
+
+const config = require('../../../config/config');
+const login = require('../../shared/login');
+
+const logger = require('../../../lib/logger');
+logger.level = 'debug';
+
+const baseTechniqueData = {
+  workspace: {
+    workflow: {
+      state: 'work-in-progress',
+    },
+  },
+  stix: {
+    name: 'convert-test-technique',
+    type: 'attack-pattern',
+    description: 'A technique for conversion tests.',
+    object_marking_refs: ['marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168'],
+    created_by_ref: 'identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5',
+    kill_chain_phases: [{ kill_chain_name: 'mitre-attack', phase_name: 'execution' }],
+    x_mitre_is_subtechnique: false,
+    x_mitre_platforms: ['Linux'],
+  },
+};
+
+describe('Techniques Convert API', function () {
+  let app;
+  let passportCookie;
+
+  before(async function () {
+    await database.initializeConnection();
+    await databaseConfiguration.checkSystemConfiguration();
+
+    config.validateRequests.withAttackDataModel = false;
+    config.validateRequests.withOpenApi = false;
+
+    app = await require('../../../index').initializeApp();
+    passportCookie = await login.loginAnonymous(app);
+  });
+
+  // =============================================
+  // Convert technique → subtechnique
+  // =============================================
+  describe('POST /api/techniques/:stixId/convert-to-subtechnique', function () {
+    let parentTechnique;
+    let technique;
+
+    it('creates a parent technique', async function () {
+      const timestamp = new Date().toISOString();
+      const body = {
+        ...baseTechniqueData,
+        stix: {
+          ...baseTechniqueData.stix,
+          name: 'parent-technique',
+          created: timestamp,
+          modified: timestamp,
+        },
+      };
+      const res = await request(app)
+        .post('/api/techniques')
+        .send(body)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(201);
+
+      parentTechnique = res.body;
+      expect(parentTechnique.workspace.attack_id).toBeDefined();
+    });
+
+    it('creates a technique to convert', async function () {
+      const timestamp = new Date().toISOString();
+      const body = {
+        ...baseTechniqueData,
+        stix: {
+          ...baseTechniqueData.stix,
+          name: 'technique-to-convert',
+          created: timestamp,
+          modified: timestamp,
+        },
+      };
+      const res = await request(app)
+        .post('/api/techniques')
+        .send(body)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(201);
+
+      technique = res.body;
+      expect(technique.stix.x_mitre_is_subtechnique).toBe(false);
+    });
+
+    it('converts the technique to a subtechnique', async function () {
+      const res = await request(app)
+        .post(`/api/techniques/${technique.stix.id}/convert-to-subtechnique`)
+        .send({ parentTechniqueAttackId: parentTechnique.workspace.attack_id })
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(200)
+        .expect('Content-Type', /json/);
+
+      const converted = res.body;
+
+      // Same STIX ID, new version
+      expect(converted.stix.id).toBe(technique.stix.id);
+      expect(converted.stix.modified).not.toBe(technique.stix.modified);
+
+      // Subtechnique fields
+      expect(converted.stix.x_mitre_is_subtechnique).toBe(true);
+      expect(converted.workspace.attack_id).toMatch(
+        new RegExp(`^${parentTechnique.workspace.attack_id}\\.\\d{3}$`),
+      );
+
+      // External reference updated
+      const attackRef = converted.stix.external_references.find(
+        (ref) => ref.source_name === 'mitre-attack',
+      );
+      expect(attackRef).toBeDefined();
+      expect(attackRef.external_id).toBe(converted.workspace.attack_id);
+      expect(attackRef.url).toContain('/techniques/');
+    });
+
+    it('returns 400 when technique is already a subtechnique', async function () {
+      await request(app)
+        .post(`/api/techniques/${technique.stix.id}/convert-to-subtechnique`)
+        .send({ parentTechniqueAttackId: parentTechnique.workspace.attack_id })
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(400);
+    });
+
+    it('returns 400 when parentTechniqueAttackId is missing', async function () {
+      await request(app)
+        .post(`/api/techniques/${technique.stix.id}/convert-to-subtechnique`)
+        .send({})
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(400);
+    });
+
+    it('returns 400 when parentTechniqueAttackId has invalid format', async function () {
+      await request(app)
+        .post(`/api/techniques/${technique.stix.id}/convert-to-subtechnique`)
+        .send({ parentTechniqueAttackId: 'INVALID' })
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(400);
+    });
+
+    it('returns 404 for non-existent stixId', async function () {
+      await request(app)
+        .post('/api/techniques/attack-pattern--does-not-exist/convert-to-subtechnique')
+        .send({ parentTechniqueAttackId: parentTechnique.workspace.attack_id })
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(404);
+    });
+  });
+
+  // =============================================
+  // Convert subtechnique → technique
+  // =============================================
+  describe('POST /api/techniques/:stixId/convert-to-technique', function () {
+    let parentTechnique;
+    let subtechnique;
+
+    it('creates a parent technique', async function () {
+      const timestamp = new Date().toISOString();
+      const body = {
+        ...baseTechniqueData,
+        stix: {
+          ...baseTechniqueData.stix,
+          name: 'parent-for-sub',
+          created: timestamp,
+          modified: timestamp,
+        },
+      };
+      const res = await request(app)
+        .post('/api/techniques')
+        .send(body)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(201);
+
+      parentTechnique = res.body;
+    });
+
+    it('creates a subtechnique', async function () {
+      const timestamp = new Date().toISOString();
+      const body = {
+        ...baseTechniqueData,
+        stix: {
+          ...baseTechniqueData.stix,
+          name: 'subtechnique-to-convert',
+          x_mitre_is_subtechnique: true,
+          created: timestamp,
+          modified: timestamp,
+        },
+      };
+      const res = await request(app)
+        .post(`/api/techniques?parentTechniqueId=${parentTechnique.workspace.attack_id}`)
+        .send(body)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(201);
+
+      subtechnique = res.body;
+      expect(subtechnique.stix.x_mitre_is_subtechnique).toBe(true);
+      expect(subtechnique.workspace.attack_id).toContain('.');
+    });
+
+    it('creates a subtechnique-of relationship', async function () {
+      const timestamp = new Date().toISOString();
+      const relBody = {
+        workspace: { workflow: { state: 'work-in-progress' } },
+        stix: {
+          spec_version: '2.1',
+          type: 'relationship',
+          relationship_type: 'subtechnique-of',
+          source_ref: subtechnique.stix.id,
+          target_ref: parentTechnique.stix.id,
+          created: timestamp,
+          modified: timestamp,
+          created_by_ref: 'identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5',
+          object_marking_refs: ['marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168'],
+        },
+      };
+      const res = await request(app)
+        .post('/api/relationships')
+        .send(relBody)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(201);
+
+      expect(res.body.stix.relationship_type).toBe('subtechnique-of');
+    });
+
+    it('converts the subtechnique to a technique', async function () {
+      const res = await request(app)
+        .post(`/api/techniques/${subtechnique.stix.id}/convert-to-technique`)
+        .send({})
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(200)
+        .expect('Content-Type', /json/);
+
+      const converted = res.body;
+
+      // Same STIX ID, new version
+      expect(converted.stix.id).toBe(subtechnique.stix.id);
+      expect(converted.stix.modified).not.toBe(subtechnique.stix.modified);
+
+      // Technique fields
+      expect(converted.stix.x_mitre_is_subtechnique).toBe(false);
+      expect(converted.workspace.attack_id).toMatch(/^T\d{4}$/);
+      expect(converted.workspace.attack_id).not.toContain('.');
+
+      // External reference updated
+      const attackRef = converted.stix.external_references.find(
+        (ref) => ref.source_name === 'mitre-attack',
+      );
+      expect(attackRef).toBeDefined();
+      expect(attackRef.external_id).toBe(converted.workspace.attack_id);
+      expect(attackRef.url).toMatch(/\/techniques\/T\d{4}$/);
+    });
+
+    it('deprecated the subtechnique-of relationship', async function () {
+      // The subtechnique-of relationship should now be deprecated
+      const res = await request(app)
+        .get(
+          `/api/relationships?sourceRef=${subtechnique.stix.id}&relationshipType=subtechnique-of&includeDeprecated=true`,
+        )
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(200);
+
+      // Find the latest version of the relationship
+      const rels = res.body;
+      expect(rels.length).toBeGreaterThan(0);
+
+      // At least one version should be deprecated
+      const deprecatedRel = rels.find((r) => r.stix.x_mitre_deprecated === true);
+      expect(deprecatedRel).toBeDefined();
+    });
+
+    it('returns 400 when technique is not a subtechnique', async function () {
+      // The subtechnique was just converted to a technique, so trying again should fail
+      await request(app)
+        .post(`/api/techniques/${subtechnique.stix.id}/convert-to-technique`)
+        .send({})
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(400);
+    });
+
+    it('returns 404 for non-existent stixId', async function () {
+      await request(app)
+        .post('/api/techniques/attack-pattern--does-not-exist/convert-to-technique')
+        .send({})
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(404);
+    });
+  });
+
+  // =============================================
+  // Block conversion when technique has child subtechniques
+  // =============================================
+  describe('Block convert-to-subtechnique when technique has children', function () {
+    let parentTechnique;
+    let childSubtechnique;
+
+    it('creates a parent technique', async function () {
+      const timestamp = new Date().toISOString();
+      const body = {
+        ...baseTechniqueData,
+        stix: {
+          ...baseTechniqueData.stix,
+          name: 'parent-with-children',
+          created: timestamp,
+          modified: timestamp,
+        },
+      };
+      const res = await request(app)
+        .post('/api/techniques')
+        .send(body)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(201);
+
+      parentTechnique = res.body;
+    });
+
+    it('creates a child subtechnique', async function () {
+      const timestamp = new Date().toISOString();
+      const body = {
+        ...baseTechniqueData,
+        stix: {
+          ...baseTechniqueData.stix,
+          name: 'child-subtechnique',
+          x_mitre_is_subtechnique: true,
+          created: timestamp,
+          modified: timestamp,
+        },
+      };
+      const res = await request(app)
+        .post(`/api/techniques?parentTechniqueId=${parentTechnique.workspace.attack_id}`)
+        .send(body)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(201);
+
+      childSubtechnique = res.body;
+    });
+
+    it('creates a subtechnique-of relationship from child to parent', async function () {
+      const timestamp = new Date().toISOString();
+      const relBody = {
+        workspace: { workflow: { state: 'work-in-progress' } },
+        stix: {
+          spec_version: '2.1',
+          type: 'relationship',
+          relationship_type: 'subtechnique-of',
+          source_ref: childSubtechnique.stix.id,
+          target_ref: parentTechnique.stix.id,
+          created: timestamp,
+          modified: timestamp,
+          created_by_ref: 'identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5',
+          object_marking_refs: ['marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168'],
+        },
+      };
+      await request(app)
+        .post('/api/relationships')
+        .send(relBody)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(201);
+    });
+
+    it('returns 400 when trying to convert a parent technique that has subtechniques', async function () {
+      const res = await request(app)
+        .post(`/api/techniques/${parentTechnique.stix.id}/convert-to-subtechnique`)
+        .send({ parentTechniqueAttackId: 'T0001' })
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(400);
+
+      expect(res.body.details).toContain('subtechnique');
+      expect(res.body.details).toContain('Rehome');
+    });
+  });
+
+  // =============================================
+  // x_mitre_is_subtechnique is preserved on update
+  // =============================================
+  describe('PUT preserves x_mitre_is_subtechnique', function () {
+    let technique;
+
+    it('creates a technique', async function () {
+      const timestamp = new Date().toISOString();
+      const body = {
+        ...baseTechniqueData,
+        stix: {
+          ...baseTechniqueData.stix,
+          name: 'immutable-subtech-field',
+          created: timestamp,
+          modified: timestamp,
+        },
+      };
+      const res = await request(app)
+        .post('/api/techniques')
+        .send(body)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(201);
+
+      technique = res.body;
+      expect(technique.stix.x_mitre_is_subtechnique).toBe(false);
+    });
+
+    it('update ignores attempt to change x_mitre_is_subtechnique', async function () {
+      const updateBody = {
+        ...technique,
+        stix: {
+          ...technique.stix,
+          x_mitre_is_subtechnique: true, // attempt to change
+          description: 'Updated description',
+        },
+      };
+
+      const res = await request(app)
+        .put(`/api/techniques/${technique.stix.id}/modified/${technique.stix.modified}`)
+        .send(updateBody)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(200);
+
+      // The field should remain false
+      expect(res.body.stix.x_mitre_is_subtechnique).toBe(false);
+      // But the description should have been updated
+      expect(res.body.stix.description).toBe('Updated description');
+    });
+  });
+
+  // =============================================
+  // Revoked technique cannot be converted
+  // =============================================
+  describe('Revoked techniques cannot be converted', function () {
+    let techniqueA;
+    let techniqueB;
+
+    it('creates two techniques', async function () {
+      const timestamp1 = new Date().toISOString();
+      const body1 = {
+        ...baseTechniqueData,
+        stix: {
+          ...baseTechniqueData.stix,
+          name: 'revoked-convert-A',
+          created: timestamp1,
+          modified: timestamp1,
+        },
+      };
+      const res1 = await request(app)
+        .post('/api/techniques')
+        .send(body1)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(201);
+      techniqueA = res1.body;
+
+      const timestamp2 = new Date().toISOString();
+      const body2 = {
+        ...baseTechniqueData,
+        stix: {
+          ...baseTechniqueData.stix,
+          name: 'revoked-convert-B',
+          created: timestamp2,
+          modified: timestamp2,
+        },
+      };
+      const res2 = await request(app)
+        .post('/api/techniques')
+        .send(body2)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(201);
+      techniqueB = res2.body;
+    });
+
+    it('revokes technique A', async function () {
+      await request(app)
+        .post(`/api/techniques/${techniqueA.stix.id}/revoke`)
+        .send({
+          revoking: { stixId: techniqueB.stix.id, modified: techniqueB.stix.modified },
+        })
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(200);
+    });
+
+    it('returns 400 when trying to convert a revoked technique to subtechnique', async function () {
+      await request(app)
+        .post(`/api/techniques/${techniqueA.stix.id}/convert-to-subtechnique`)
+        .send({ parentTechniqueAttackId: techniqueB.workspace.attack_id })
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(400);
+    });
+  });
+
+  after(async function () {
+    await database.closeConnection();
+  });
+});

--- a/app/tests/api/techniques/techniques.convert.spec.js
+++ b/app/tests/api/techniques/techniques.convert.spec.js
@@ -103,7 +103,14 @@ describe('Techniques Convert API', function () {
         .expect(200)
         .expect('Content-Type', /json/);
 
-      const converted = res.body;
+      const body = res.body;
+
+      // WorkflowResult envelope
+      expect(body.workflow).toBe('convert-to-subtechnique');
+      expect(body.primary).toBeDefined();
+      expect(body.sideEffects).toBeDefined();
+
+      const converted = body.primary;
 
       // Same STIX ID, new version
       expect(converted.stix.id).toBe(technique.stix.id);
@@ -122,6 +129,13 @@ describe('Techniques Convert API', function () {
       expect(attackRef).toBeDefined();
       expect(attackRef.external_id).toBe(converted.workspace.attack_id);
       expect(attackRef.url).toContain('/techniques/');
+
+      // Side effect: subtechnique-of relationship was created
+      expect(body.sideEffects.created.length).toBe(1);
+      const createdRel = body.sideEffects.created[0];
+      expect(createdRel.stix.relationship_type).toBe('subtechnique-of');
+      expect(createdRel.stix.source_ref).toBe(technique.stix.id);
+      expect(createdRel.stix.target_ref).toBe(parentTechnique.stix.id);
     });
 
     it('returns 400 when technique is already a subtechnique', async function () {
@@ -146,6 +160,16 @@ describe('Techniques Convert API', function () {
       await request(app)
         .post(`/api/techniques/${technique.stix.id}/convert-to-subtechnique`)
         .send({ parentTechniqueAttackId: 'INVALID' })
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(400);
+    });
+
+    it('returns 400 when parentTechniqueAttackId does not exist', async function () {
+      // T9999 has valid format but no technique with this ATT&CK ID exists
+      await request(app)
+        .post(`/api/techniques/${technique.stix.id}/convert-to-subtechnique`)
+        .send({ parentTechniqueAttackId: 'T9999' })
         .set('Accept', 'application/json')
         .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
         .expect(400);
@@ -248,7 +272,14 @@ describe('Techniques Convert API', function () {
         .expect(200)
         .expect('Content-Type', /json/);
 
-      const converted = res.body;
+      const body = res.body;
+
+      // WorkflowResult envelope
+      expect(body.workflow).toBe('convert-to-technique');
+      expect(body.primary).toBeDefined();
+      expect(body.sideEffects).toBeDefined();
+
+      const converted = body.primary;
 
       // Same STIX ID, new version
       expect(converted.stix.id).toBe(subtechnique.stix.id);
@@ -266,25 +297,12 @@ describe('Techniques Convert API', function () {
       expect(attackRef).toBeDefined();
       expect(attackRef.external_id).toBe(converted.workspace.attack_id);
       expect(attackRef.url).toMatch(/\/techniques\/T\d{4}$/);
-    });
 
-    it('deprecated the subtechnique-of relationship', async function () {
-      // The subtechnique-of relationship should now be deprecated
-      const res = await request(app)
-        .get(
-          `/api/relationships?sourceRef=${subtechnique.stix.id}&relationshipType=subtechnique-of&includeDeprecated=true`,
-        )
-        .set('Accept', 'application/json')
-        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
-        .expect(200);
-
-      // Find the latest version of the relationship
-      const rels = res.body;
-      expect(rels.length).toBeGreaterThan(0);
-
-      // At least one version should be deprecated
-      const deprecatedRel = rels.find((r) => r.stix.x_mitre_deprecated === true);
-      expect(deprecatedRel).toBeDefined();
+      // Side effect: subtechnique-of relationship was deprecated
+      expect(body.sideEffects.deprecated.length).toBeGreaterThan(0);
+      const deprecatedRel = body.sideEffects.deprecated[0];
+      expect(deprecatedRel.stix.relationship_type).toBe('subtechnique-of');
+      expect(deprecatedRel.stix.x_mitre_deprecated).toBe(true);
     });
 
     it('returns 400 when technique is not a subtechnique', async function () {
@@ -313,6 +331,7 @@ describe('Techniques Convert API', function () {
   describe('Block convert-to-subtechnique when technique has children', function () {
     let parentTechnique;
     let childSubtechnique;
+    let wouldBeParent;
 
     it('creates a parent technique', async function () {
       const timestamp = new Date().toISOString();
@@ -333,6 +352,27 @@ describe('Techniques Convert API', function () {
         .expect(201);
 
       parentTechnique = res.body;
+    });
+
+    it('creates a would-be parent technique for the conversion attempt', async function () {
+      const timestamp = new Date().toISOString();
+      const body = {
+        ...baseTechniqueData,
+        stix: {
+          ...baseTechniqueData.stix,
+          name: 'would-be-parent',
+          created: timestamp,
+          modified: timestamp,
+        },
+      };
+      const res = await request(app)
+        .post('/api/techniques')
+        .send(body)
+        .set('Accept', 'application/json')
+        .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
+        .expect(201);
+
+      wouldBeParent = res.body;
     });
 
     it('creates a child subtechnique', async function () {
@@ -384,7 +424,7 @@ describe('Techniques Convert API', function () {
     it('returns 400 when trying to convert a parent technique that has subtechniques', async function () {
       const res = await request(app)
         .post(`/api/techniques/${parentTechnique.stix.id}/convert-to-subtechnique`)
-        .send({ parentTechniqueAttackId: 'T0001' })
+        .send({ parentTechniqueAttackId: wouldBeParent.workspace.attack_id })
         .set('Accept', 'application/json')
         .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
         .expect(400);

--- a/app/tests/api/techniques/techniques.revoke.spec.js
+++ b/app/tests/api/techniques/techniques.revoke.spec.js
@@ -201,19 +201,21 @@ describe('Techniques Revoke API', function () {
 
     revokeResult = res.body;
 
-    // Verify the response structure
-    expect(revokeResult.revokedObject).toBeDefined();
-    expect(revokeResult.revokedByRelationship).toBeDefined();
-    expect(revokeResult.relationshipsSummary).toBeDefined();
+    // Verify the WorkflowResult envelope
+    expect(revokeResult.workflow).toBe('revoke');
+    expect(revokeResult.primary).toBeDefined();
+    expect(revokeResult.sideEffects).toBeDefined();
 
-    // Verify the revoked object
-    expect(revokeResult.revokedObject.stix.id).toBe(techniqueA.stix.id);
-    expect(revokeResult.revokedObject.stix.revoked).toBe(true);
+    // Verify the revoked object (primary)
+    expect(revokeResult.primary.stix.id).toBe(techniqueA.stix.id);
+    expect(revokeResult.primary.stix.revoked).toBe(true);
 
-    // Verify the revoked-by relationship
-    expect(revokeResult.revokedByRelationship.stix.relationship_type).toBe('revoked-by');
-    expect(revokeResult.revokedByRelationship.stix.source_ref).toBe(techniqueA.stix.id);
-    expect(revokeResult.revokedByRelationship.stix.target_ref).toBe(techniqueB.stix.id);
+    // Verify the revoked-by relationship (first created side effect)
+    expect(revokeResult.sideEffects.created.length).toBeGreaterThan(0);
+    const revokedByRel = revokeResult.sideEffects.created[0];
+    expect(revokedByRel.stix.relationship_type).toBe('revoked-by');
+    expect(revokedByRel.stix.source_ref).toBe(techniqueA.stix.id);
+    expect(revokedByRel.stix.target_ref).toBe(techniqueB.stix.id);
   });
 
   it('GET /api/techniques/:stixId returns the revoked technique with revoked = true', async function () {
@@ -381,8 +383,9 @@ describe('Techniques Revoke API', function () {
       .expect('Content-Type', /json/);
 
     const result = revokeRes.body;
-    expect(result.relationshipsSummary.transferred).toBe(1);
-    expect(result.relationshipsSummary.deprecated).toBeGreaterThanOrEqual(1);
+    // revoked-by + 1 transferred relationship = 2 created
+    expect(result.sideEffects.created.length).toBe(2);
+    expect(result.sideEffects.deprecated.length).toBeGreaterThanOrEqual(1);
 
     // Verify the original relationship was deprecated (not deleted — history preserved)
     const relRes2 = await request(app)
@@ -524,8 +527,9 @@ describe('Techniques Revoke API', function () {
     const result = revokeRes.body;
 
     // The duplicate should have been skipped, not transferred
-    expect(result.relationshipsSummary.transferred).toBe(0);
-    expect(result.relationshipsSummary.duplicatesSkipped).toBe(1);
+    // Only the revoked-by relationship should be in created (no transferred relationships)
+    expect(result.sideEffects.created.length).toBe(1);
+    expect(result.sideEffects.created[0].stix.relationship_type).toBe('revoked-by');
 
     // Verify exactly one "mitigates" relationship exists from M1 → F (the pre-existing one)
     const relsRes = await request(app)

--- a/app/tests/middleware/adm-validation-middleware.spec.js
+++ b/app/tests/middleware/adm-validation-middleware.spec.js
@@ -471,7 +471,7 @@ describe('ADM Validation Middleware', function () {
         },
         stix: {
           ...createdObject.stix,
-          x_mitre_is_subtechnique: 'not-a-boolean', // Invalid type
+          description: true, // <-- should trigger validation error (should be string)
         },
       };
 

--- a/docs/developer/workflow-response-pattern.md
+++ b/docs/developer/workflow-response-pattern.md
@@ -1,0 +1,246 @@
+# Workflow Response Pattern
+
+## Overview
+
+The ATT&CK Workbench REST API exposes several backend workflow endpoints that orchestrate complex, multi-step operations in a single atomic request. Examples include revoking an object, converting a technique to a subtechnique, and converting a subtechnique to a technique.
+
+These workflows create, modify, deprecate, or delete multiple documents as side effects. The user needs visibility into all changes that occurred as a consequence of their request. To support this, all workflow endpoints return a universal response structure called a **Workflow Result**.
+
+## Response Schema
+
+Every workflow endpoint returns the same top-level shape:
+
+```json
+{
+  "workflow": "convert-to-subtechnique",
+  "primary": {
+    "workspace": { ... },
+    "stix": { ... }
+  },
+  "sideEffects": {
+    "created":    [ { "workspace": { ... }, "stix": { ... } } ],
+    "modified":   [],
+    "deprecated": [],
+    "deleted":    { "count": 0, "stixIds": [] }
+  },
+  "warnings": []
+}
+```
+
+### Field Reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workflow` | `string` | Discriminator identifying which workflow was executed. One of: `"revoke"`, `"convert-to-subtechnique"`, `"convert-to-technique"`. |
+| `primary` | `object` | The main object the user acted on. Always exactly one full `workspace + stix` document. |
+| `sideEffects.created` | `array` | Full documents created as consequences of the workflow (e.g., `revoked-by` relationship, `subtechnique-of` relationship). |
+| `sideEffects.modified` | `array` | Full documents modified as consequences (e.g., transferred relationships). |
+| `sideEffects.deprecated` | `array` | Full documents that had `x_mitre_deprecated` set to `true` as a consequence. |
+| `sideEffects.deleted` | `object` | Hard-deleted documents. Only count + STIX IDs are returned (the documents no longer exist). |
+| `sideEffects.deleted.count` | `integer` | Number of deleted documents. |
+| `sideEffects.deleted.stixIds` | `array<string>` | STIX IDs of deleted documents. |
+| `warnings` | `array<string>` | Non-fatal issues encountered during the workflow (e.g., a relationship that could not be deprecated). |
+
+**Design rationale:** Counts are derivable from array lengths, so no separate summary object is needed. The `deleted` category is the sole exception because deleted documents cannot be returned in full — only their IDs survive.
+
+## Which Endpoints Use This Pattern
+
+| Endpoint | `workflow` value | `primary` | Typical side effects |
+|----------|-----------------|-----------|----------------------|
+| `POST /api/:type/:stixId/revoke` | `"revoke"` | Revoked object | `created`: revoked-by relationship; `deprecated`: relationships referencing the revoked object |
+| `POST /api/techniques/:stixId/convert-to-subtechnique` | `"convert-to-subtechnique"` | Converted subtechnique | `created`: subtechnique-of relationship |
+| `POST /api/techniques/:stixId/convert-to-technique` | `"convert-to-technique"` | Converted technique | `deprecated`: subtechnique-of relationship(s) |
+
+## WorkflowResult Builder
+
+The `WorkflowResult` class (`app/lib/workflow-result.js`) is a DTO builder that assembles the response. Services construct a `WorkflowResult`, populate it, then return `result.toJSON()`.
+
+### API
+
+```javascript
+const WorkflowResult = require('../../lib/workflow-result');
+
+// Create
+const result = new WorkflowResult('convert-to-subtechnique');
+
+// Set the primary object
+result.setPrimary(savedDocument);
+
+// Add side effects
+result.addCreated(relationshipDoc);        // single doc or array
+result.addModified(transferredRelDoc);     // single doc or array
+result.addDeprecated(deprecatedRelDoc);    // single doc or array
+result.addDeleted(['attack-pattern--...']); // array of STIX IDs
+
+// Add warnings
+result.addWarning('Could not deprecate relationship--...');
+
+// Merge results returned by event handlers (see below)
+const eventResults = await EventBus.emit(eventName, payload);
+result.mergeEventResults(eventResults);
+
+// Serialize (calls .toObject() on Mongoose docs, strips _id/__v/__t)
+return result.toJSON();
+```
+
+### `mergeEventResults(eventResults)`
+
+Accepts the array returned by `EventBus.emit()` and merges each handler's result into the appropriate side-effect category:
+
+```javascript
+mergeEventResults(eventResults) {
+  for (const handlerResult of eventResults) {
+    if (handlerResult.created)    this.addCreated(handlerResult.created);
+    if (handlerResult.modified)   this.addModified(handlerResult.modified);
+    if (handlerResult.deprecated) this.addDeprecated(handlerResult.deprecated);
+    if (handlerResult.warnings)   this.addWarnings(handlerResult.warnings);
+  }
+}
+```
+
+## Event Handler Return Contract
+
+To surface side effects in the workflow response, event handlers must return their results.
+
+### Before (results discarded)
+
+```javascript
+static async handleSubtechniqueConvertedToTechnique(payload) {
+  // ... deprecate relationships ...
+  logger.info(`Deprecated ${count} relationships`);
+  // Returns undefined — caller has no visibility
+}
+```
+
+### After (results returned)
+
+```javascript
+static async handleSubtechniqueConvertedToTechnique(payload) {
+  // ... deprecate relationships ...
+  return { deprecated: deprecatedDocs };
+}
+```
+
+### Return Shape
+
+Event handlers return a plain object with any subset of these keys:
+
+```javascript
+{
+  created:    [ /* full documents */ ],
+  modified:   [ /* full documents */ ],
+  deprecated: [ /* full documents */ ],
+  warnings:   [ /* string messages */ ]
+}
+```
+
+Handlers that encounter errors in their catch blocks should return `{ warnings: [...] }` rather than swallowing the error silently:
+
+```javascript
+} catch (error) {
+  logger.error(`Failed to deprecate relationship ${relId}: ${error.message}`);
+  return { warnings: [`Failed to deprecate relationship ${relId}`] };
+}
+```
+
+## EventBus: Returning Handler Results
+
+`EventBus.emit()` uses `Promise.allSettled` to execute listeners. It collects the fulfilled return values and returns them as an array:
+
+```javascript
+async emit(eventName, payload) {
+  // ... existing logging ...
+  const results = await Promise.allSettled(
+    listeners.map(async (listener) => {
+      return await listener(payload);  // return value preserved
+    }),
+  );
+
+  // Return fulfilled values (undefined returns filtered out)
+  return results
+    .filter((r) => r.status === 'fulfilled' && r.value != null)
+    .map((r) => r.value);
+}
+```
+
+This is backward-compatible: callers that do not inspect the return value are unaffected. Handlers that do not return anything produce `undefined`, which is filtered out.
+
+## Usage Example: Convert to Subtechnique
+
+Full flow from service → event handler → response:
+
+```javascript
+// In TechniquesService.convertToSubtechnique():
+const result = new WorkflowResult('convert-to-subtechnique');
+
+// 1. Save the converted technique
+const savedDocument = await this.repository.save(newVersion);
+result.setPrimary(savedDocument);
+
+// 2. Emit event — RelationshipsService creates the subtechnique-of SRO
+const eventResults = await EventBus.emit(
+  EventConstants.TECHNIQUE_CONVERTED_TO_SUBTECHNIQUE,
+  { stixId, parentStixId, userAccountId },
+);
+result.mergeEventResults(eventResults);
+
+// 3. Return the assembled response
+return result.toJSON();
+
+
+// In RelationshipsService.handleTechniqueConvertedToSubtechnique():
+static async handleTechniqueConvertedToSubtechnique(payload) {
+  const { stixId, parentStixId, userAccountId } = payload;
+  try {
+    const rel = await relationshipsService.create({ ... }, { userAccountId });
+    return { created: [rel] };
+  } catch (error) {
+    logger.error(`Failed to create subtechnique-of: ${error.message}`);
+    return { warnings: [`Failed to create subtechnique-of relationship for ${stixId}`] };
+  }
+}
+```
+
+The HTTP response body will be:
+
+```json
+{
+  "workflow": "convert-to-subtechnique",
+  "primary": {
+    "workspace": { "attack_id": "T1234.001", ... },
+    "stix": { "x_mitre_is_subtechnique": true, ... }
+  },
+  "sideEffects": {
+    "created": [
+      {
+        "stix": {
+          "type": "relationship",
+          "relationship_type": "subtechnique-of",
+          "source_ref": "attack-pattern--...",
+          "target_ref": "attack-pattern--..."
+        }
+      }
+    ],
+    "modified": [],
+    "deprecated": [],
+    "deleted": { "count": 0, "stixIds": [] }
+  },
+  "warnings": []
+}
+```
+
+## Adding a New Workflow: Checklist
+
+1. Choose a `workflow` discriminator string (e.g., `"deprecate"`).
+2. In your service method:
+   - Create `new WorkflowResult('your-workflow-name')`
+   - Call `result.setPrimary(...)` after persisting the primary object
+   - Call `result.addCreated/addDeprecated/etc.` for any side effects performed directly
+   - Capture `EventBus.emit()` return value and call `result.mergeEventResults(...)`
+   - Return `result.toJSON()`
+3. In each event handler that produces side effects:
+   - Return `{ created, modified, deprecated, warnings }` (include only the keys that apply)
+   - On error, return `{ warnings: [...] }` instead of swallowing silently
+4. Add the new workflow value to the `workflow` enum in the OpenAPI schema (`app/api/definitions/components/workflow-response.yml`).
+5. Reference the `workflow-response` schema in the endpoint's OpenAPI path definition.
+6. Update user-facing documentation in `docs/user/`.

--- a/docs/user/revoke-workflow.md
+++ b/docs/user/revoke-workflow.md
@@ -32,98 +32,69 @@ Specify the `id` and `modified` timestamp for the revoked object in the request 
 
 Optionally, you can set the following query parameter to preserve relationships:
 
-- `preserveRelationships` (boolean): If set to `true`, the workflow will attempt to preserve existing relationships by substituting the revoked object with the new revoked version in those relationships. If not set or set to `false`, all relationships involving the revoked object will be deleted. Notably, if the revoking object (Object B) already participates in a relationship with the same source, target, and relationship type as an existing relationship of the revoked object (Object A), that relationship will be preserved as-is without creating a new relationship for Object B. 
+- `preserveRelationships` (boolean): If set to `true`, the workflow clones each relationship that references the revoked object so that it points to the revoking object instead, then deprecates the original. If not set or set to `false`, relationships referencing the revoked object are deprecated without being transferred. If the revoking object (Object B) already participates in a relationship with the same source, target, and relationship type as an existing relationship of the revoked object (Object A), the transfer is skipped and a warning is included in the response.
 
 ## Response
 
 ### Success Response
 
-On success, the API will return a 200 OK response with the following body, which includes the revoked object, the new "revoked-by" relationship, and a summary of how relationships were handled:
+On success, the API returns a **200 OK** with a [workflow response envelope](../../docs/developer/workflow-response-pattern.md). The response includes the revoked object, the `revoked-by` relationship, any transferred relationships, and any deprecated relationships:
 
 ```json
 {
-  "revokedObject": {
+  "workflow": "revoke",
+  "primary": {
     "workspace": {
-      "workflow": {
-        "state": "work-in-progress",
-        "created_by_user_account": "identity--3562fbf3-795f-4955-8e64-6c964f598e1c"
-      },
-      "attack_id": "T0006",
-      "collections": [],
-      "embedded_relationships": []
+      "workflow": { "state": "work-in-progress" },
+      "attack_id": "T0006"
     },
     "stix": {
       "type": "attack-pattern",
       "spec_version": "2.1",
       "id": "attack-pattern--83efdc56-d35f-4508-9f10-152bbfffde79",
-      "created": "2026-03-27T14:31:52.711Z",
-      "created_by_ref": "identity--c21f0782-50a8-4e5f-87a1-b56703e78e48",
       "revoked": true,
-      "external_references": [
-        {
-          "source_name": "mitre-attack",
-          "url": "https://attack.mitre.org/techniques/T0006",
-          "external_id": "T0006"
-        }
-      ],
-      "object_marking_refs": [
-        "marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168"
-      ],
       "modified": "2026-03-27T14:31:52.744Z",
-      "name": "technique-E",
-      "description": "This technique will be revoked.",
-      "kill_chain_phases": [
-        {
-          "kill_chain_name": "kill-chain-name-1",
-          "phase_name": "phase-1"
-        }
-      ],
-      "x_mitre_attack_spec_version": "3.3.0",
-      "x_mitre_contributors": [],
-      "x_mitre_deprecated": false,
-      "x_mitre_is_subtechnique": false,
-      "x_mitre_modified_by_ref": "identity--c21f0782-50a8-4e5f-87a1-b56703e78e48",
-      "x_mitre_platforms": [
-        "platform-1"
-      ]
+      "name": "technique-E"
     }
   },
-  "revokedByRelationship": {
-    "workspace": {
-      "workflow": {
-        "created_by_user_account": "identity--3562fbf3-795f-4955-8e64-6c964f598e1c"
-      },
-      "collections": [],
-      "embedded_relationships": []
-    },
-    "stix": {
-      "type": "relationship",
-      "spec_version": "2.1",
-      "id": "relationship--64d45634-f855-4fea-b084-33a87858406d",
-      "created": "2026-03-27T14:31:52.745Z",
-      "created_by_ref": "identity--c21f0782-50a8-4e5f-87a1-b56703e78e48",
-      "object_marking_refs": [],
-      "modified": "2026-03-27T14:31:52.745Z",
-      "relationship_type": "revoked-by",
-      "source_ref": "attack-pattern--83efdc56-d35f-4508-9f10-152bbfffde79",
-      "target_ref": "attack-pattern--ab992c5a-4a03-4374-ad15-440fac072760",
-      "x_mitre_modified_by_ref": "identity--c21f0782-50a8-4e5f-87a1-b56703e78e48",
-      "x_mitre_attack_spec_version": "3.3.0",
-      "external_references": []
-    },
-    "_id": "69c694d8eb64093bcd182721",
-    "__v": 0,
-    "warnings": []
+  "sideEffects": {
+    "created": [
+      {
+        "workspace": { "workflow": {} },
+        "stix": {
+          "type": "relationship",
+          "relationship_type": "revoked-by",
+          "source_ref": "attack-pattern--83efdc56-d35f-4508-9f10-152bbfffde79",
+          "target_ref": "attack-pattern--ab992c5a-4a03-4374-ad15-440fac072760"
+        }
+      }
+    ],
+    "modified": [],
+    "deprecated": [
+      {
+        "workspace": { "workflow": { "state": "reviewed" } },
+        "stix": {
+          "type": "relationship",
+          "relationship_type": "uses",
+          "x_mitre_deprecated": true
+        }
+      }
+    ],
+    "deleted": { "count": 0, "stixIds": [] }
   },
-  "relationshipsSummary": {
-    "deleted": 1,
-    "transferred": 0,
-    "warnings": [],
-    "duplicatesSkipped": 1
-  }
+  "warnings": []
 }
 ```
 
+| Field | Description |
+|-------|-------------|
+| `workflow` | Always `"revoke"` |
+| `primary` | The technique in its post-revocation state (`revoked: true`) |
+| `sideEffects.created` | The `revoked-by` relationship, plus any transferred relationships (when `preserveRelationships=true`) |
+| `sideEffects.deprecated` | Relationships that referenced the revoked object, deprecated with `x_mitre_deprecated: true` |
+| `warnings` | Non-fatal issues (e.g., duplicate relationships skipped during transfer) |
+
+> **Note:** When `preserveRelationships=true`, relationships are cloned to point to the revoking object (appearing in `sideEffects.created`) and the originals are deprecated (appearing in `sideEffects.deprecated`). If a duplicate relationship already exists on the revoking object, the transfer is skipped and a warning is emitted instead.
 
 ### Error Responses
 

--- a/docs/user/technique-conversion-workflow.md
+++ b/docs/user/technique-conversion-workflow.md
@@ -1,0 +1,217 @@
+# Technique Conversion Workflows
+
+There are two conversion workflows for techniques:
+
+- **Convert to subtechnique** — promotes a standalone technique to a subtechnique of an existing parent technique.
+- **Convert to technique** — promotes a subtechnique to a standalone technique, removing its parent association.
+
+Both workflows create a new version of the object (same `stix.id`, new `modified` timestamp) with updated properties. The `x_mitre_is_subtechnique` field cannot be changed through a normal PUT update — these endpoints are the only way to change a technique's subtechnique status.
+
+## Convert Technique to Subtechnique
+
+### Usage
+
+```
+POST /api/techniques/:stixId/convert-to-subtechnique
+```
+
+Where `:stixId` is the STIX ID of the technique to convert (e.g., `attack-pattern--15dbf668-795c-41e6-8219-f0447c0e64ce`).
+
+Requires **editor** role or higher.
+
+**Request Body:**
+
+```json
+{
+  "parentTechniqueAttackId": "T1234"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `parentTechniqueAttackId` | string | yes | ATT&CK ID of the parent technique. Must match the pattern `T####` and refer to an existing, non-revoked technique. |
+
+### What Happens
+
+1. **Validation** — The endpoint verifies that:
+   - The target technique exists and is not already a subtechnique
+   - The target technique is not revoked
+   - The target technique has no child subtechniques (rehome them first)
+   - The parent technique (`parentTechniqueAttackId`) exists in the system
+
+2. **New version created** — A new version of the technique is saved with:
+   - `x_mitre_is_subtechnique` set to `true`
+   - A new ATT&CK ID in subtechnique format (e.g., `T1234.001`), auto-generated as the next available number under the parent
+   - Updated `external_references` with the new ATT&CK ID and URL
+   - A new `modified` timestamp
+
+3. **Relationship created** — A `subtechnique-of` relationship is created linking the converted subtechnique (`source_ref`) to the parent technique (`target_ref`).
+
+### Response
+
+On success, returns **200 OK** with a [workflow response envelope](../../docs/developer/workflow-response-pattern.md):
+
+```json
+{
+  "workflow": "convert-to-subtechnique",
+  "primary": {
+    "workspace": {
+      "workflow": { "state": "work-in-progress" },
+      "attack_id": "T1234.001"
+    },
+    "stix": {
+      "type": "attack-pattern",
+      "id": "attack-pattern--15dbf668-795c-41e6-8219-f0447c0e64ce",
+      "name": "Example Technique",
+      "x_mitre_is_subtechnique": true,
+      "external_references": [
+        {
+          "source_name": "mitre-attack",
+          "external_id": "T1234.001",
+          "url": "https://attack.mitre.org/techniques/T1234/001"
+        }
+      ]
+    }
+  },
+  "sideEffects": {
+    "created": [
+      {
+        "workspace": { "workflow": { "state": "reviewed" } },
+        "stix": {
+          "type": "relationship",
+          "relationship_type": "subtechnique-of",
+          "source_ref": "attack-pattern--15dbf668-795c-41e6-8219-f0447c0e64ce",
+          "target_ref": "attack-pattern--a1234567-abcd-1234-abcd-1234567890ab"
+        }
+      }
+    ],
+    "modified": [],
+    "deprecated": [],
+    "deleted": { "count": 0, "stixIds": [] }
+  },
+  "warnings": []
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `workflow` | Always `"convert-to-subtechnique"` |
+| `primary` | The technique in its post-conversion state (new version) |
+| `sideEffects.created` | The `subtechnique-of` relationship linking the new subtechnique to its parent |
+| `sideEffects.deprecated` | Empty for this workflow |
+| `warnings` | Non-fatal issues encountered during the workflow |
+
+### Error Responses
+
+#### 400 Bad Request
+
+| Condition | Details |
+|-----------|---------|
+| Technique is already a subtechnique | `Technique attack-pattern--... is already a subtechnique` |
+| Technique is revoked | `Cannot convert a revoked technique` |
+| Technique has child subtechniques | `Technique attack-pattern--... has N subtechnique(s). Rehome or remove the subtechnique-of relationships before converting this technique to a subtechnique.` |
+| Parent technique does not exist | `Parent technique with ATT&CK ID T#### not found` |
+| `parentTechniqueAttackId` missing | Missing parameter error |
+| `parentTechniqueAttackId` invalid format | `Invalid parent technique ATT&CK ID format: .... Must be T####.` |
+
+#### 404 Not Found
+
+Returned when the target technique (`stixId`) does not exist.
+
+---
+
+## Convert Subtechnique to Technique
+
+### Usage
+
+```
+POST /api/techniques/:stixId/convert-to-technique
+```
+
+Where `:stixId` is the STIX ID of the subtechnique to convert.
+
+Requires **editor** role or higher.
+
+No request body is required.
+
+### What Happens
+
+1. **Validation** — The endpoint verifies that:
+   - The target technique exists and is currently a subtechnique (`x_mitre_is_subtechnique` is `true`)
+   - The target technique is not revoked
+
+2. **New version created** — A new version of the technique is saved with:
+   - `x_mitre_is_subtechnique` set to `false`
+   - A new ATT&CK ID in technique format (e.g., `T1235`), auto-generated as the next available number
+   - Updated `external_references` with the new ATT&CK ID and URL
+   - A new `modified` timestamp
+
+3. **Relationship deprecated** — Any active `subtechnique-of` relationships where this object is the `source_ref` are deprecated (a new version of each relationship is created with `x_mitre_deprecated` set to `true`). The original relationship versions are preserved in history.
+
+### Response
+
+On success, returns **200 OK** with a [workflow response envelope](../../docs/developer/workflow-response-pattern.md):
+
+```json
+{
+  "workflow": "convert-to-technique",
+  "primary": {
+    "workspace": {
+      "workflow": { "state": "work-in-progress" },
+      "attack_id": "T1235"
+    },
+    "stix": {
+      "type": "attack-pattern",
+      "id": "attack-pattern--15dbf668-795c-41e6-8219-f0447c0e64ce",
+      "name": "Example Subtechnique",
+      "x_mitre_is_subtechnique": false,
+      "external_references": [
+        {
+          "source_name": "mitre-attack",
+          "external_id": "T1235",
+          "url": "https://attack.mitre.org/techniques/T1235"
+        }
+      ]
+    }
+  },
+  "sideEffects": {
+    "created": [],
+    "modified": [],
+    "deprecated": [
+      {
+        "workspace": { "workflow": { "state": "reviewed" } },
+        "stix": {
+          "type": "relationship",
+          "relationship_type": "subtechnique-of",
+          "source_ref": "attack-pattern--15dbf668-795c-41e6-8219-f0447c0e64ce",
+          "target_ref": "attack-pattern--a1234567-abcd-1234-abcd-1234567890ab",
+          "x_mitre_deprecated": true
+        }
+      }
+    ],
+    "deleted": { "count": 0, "stixIds": [] }
+  },
+  "warnings": []
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `workflow` | Always `"convert-to-technique"` |
+| `primary` | The technique in its post-conversion state (new version) |
+| `sideEffects.deprecated` | The `subtechnique-of` relationship(s) that were deprecated |
+| `sideEffects.created` | Empty for this workflow |
+| `warnings` | Non-fatal issues encountered during the workflow |
+
+### Error Responses
+
+#### 400 Bad Request
+
+| Condition | Details |
+|-----------|---------|
+| Technique is not a subtechnique | `Technique attack-pattern--... is not a subtechnique` |
+| Technique is revoked | `Cannot convert a revoked technique` |
+
+#### 404 Not Found
+
+Returned when the target technique (`stixId`) does not exist.


### PR DESCRIPTION
# Features

## Adds two new workflows for technique conversions

### Convert Technique to Subtechnique

```
POST /api/techniques/:stixId/convert-to-subtechnique
```

### Convert Subtechnique to Technique

```
POST /api/techniques/:stixId/convert-to-technique
```


See [user documentation](https://github.com/center-for-threat-informed-defense/attack-workbench-rest-api/blob/technique-convert-workflows/docs/user/technique-conversion-workflow.md) for details

## Introduces new DTO enveloping pattern for handling response bodies for workflow endpoints

The ATT&CK Workbench REST API exposes several backend workflow endpoints that orchestrate complex, multi-step operations in a single atomic request. Examples include revoking an object, converting a technique to a subtechnique, and converting a subtechnique to a technique.

These workflows create, modify, deprecate, or delete multiple documents as side effects. The user needs visibility into all changes that occurred as a consequence of their request. To support this, all workflow endpoints return a universal response structure called a Workflow Result.

**Response Schema**:
Every workflow endpoint returns the same top-level shape:

```json
{
  "workflow": "convert-to-subtechnique",
  "primary": {
    "workspace": { ... },
    "stix": { ... }
  },
  "sideEffects": {
    "created":    [ { "workspace": { ... }, "stix": { ... } } ],
    "modified":   [],
    "deprecated": [],
    "deleted":    { "count": 0, "stixIds": [] }
  },
  "warnings": []
}
```

See [developer documentation](https://github.com/center-for-threat-informed-defense/attack-workbench-rest-api/blob/technique-convert-workflows/docs/developer/workflow-response-pattern.md) for details