### PR TITLE
fix: generate ATT&CK external reference for matrix objects

### DIFF
--- a/app/lib/external-reference-builder.js
+++ b/app/lib/external-reference-builder.js
@@ -18,6 +18,7 @@ const STIX_TYPE_TO_URL_PATH = {
   'x-mitre-analytic': 'analytics',
   'x-mitre-asset': 'assets',
   'x-mitre-tactic': 'tactics',
+  'x-mitre-matrix': 'matrices',
 };
 
 /**
@@ -65,13 +66,20 @@ function buildAttackExternalReference(attackId, stixType, options = {}) {
   }
 
   let url;
-  const isSubtechnique = options.isSubtechnique || attackId.includes('.');
-  if (stixType === 'attack-pattern' && isSubtechnique) {
-    // Subtechniques use format: /techniques/T1234/001
-    const [parentId, subId] = attackId.split('.');
-    url = `https://attack.mitre.org/${urlPath}/${parentId}/${subId}`;
+  if (stixType === 'x-mitre-matrix') {
+    // Matrices use the domain name as external_id (e.g., "enterprise-attack")
+    // and the URL path strips the "-attack" suffix (e.g., /matrices/enterprise)
+    const urlSegment = attackId.replace(/-attack$/, '');
+    url = `https://attack.mitre.org/${urlPath}/${urlSegment}`;
   } else {
-    url = `https://attack.mitre.org/${urlPath}/${attackId}`;
+    const isSubtechnique = options.isSubtechnique || attackId.includes('.');
+    if (stixType === 'attack-pattern' && isSubtechnique) {
+      // Subtechniques use format: /techniques/T1234/001
+      const [parentId, subId] = attackId.split('.');
+      url = `https://attack.mitre.org/${urlPath}/${parentId}/${subId}`;
+    } else {
+      url = `https://attack.mitre.org/${urlPath}/${attackId}`;
+    }
   }
 
   return {
@@ -121,8 +129,20 @@ function extractParentDetectionStrategyId(data) {
  * @returns {object|null} The ATT&CK external reference object, or null if not applicable
  */
 function createAttackExternalReference(data) {
-  const attackId = data.workspace?.attack_id;
   const stixType = data.stix?.type;
+
+  // Matrices don't have ATT&CK IDs; their external_id is the domain name
+  // (e.g., "enterprise-attack") taken from x_mitre_domains[0].
+  if (stixType === 'x-mitre-matrix') {
+    const domain = data.stix?.x_mitre_domains?.[0];
+    if (!domain) {
+      logger.debug('Matrix has no x_mitre_domains; omitting ATT&CK external reference');
+      return null;
+    }
+    return buildAttackExternalReference(domain, stixType);
+  }
+
+  const attackId = data.workspace?.attack_id;
 
   if (!attackId) {
     // No ATT&CK ID means no external reference to generate.

--- a/app/repository/techniques-repository.js
+++ b/app/repository/techniques-repository.js
@@ -7,19 +7,34 @@ const { DatabaseError } = require('../exceptions');
 class TechniqueRepository extends BaseRepository {
   /**
    * Retrieve the latest version of each technique whose kill_chain_phases contains
-   * a phase with the given phase_name. Returns plain objects (no _id or internal fields).
+   * a phase with the given phase_name (and optionally matching kill_chain_name).
+   * Returns plain objects (no _id or internal fields).
    * Used when creating new technique versions to propagate a tactic shortname change.
    *
    * @param {string} phaseName - The phase_name value to filter by
+   * @param {string[]} [killChainNames] - If non-empty, only match phases whose
+   *   kill_chain_name is in this list (scopes the change to specific domains)
    * @returns {Promise<Array<Object>>} Array of plain technique objects (latest version each)
    */
-  async retrieveAllLatestByPhaseName(phaseName) {
+  async retrieveAllLatestByPhaseName(phaseName, killChainNames = []) {
     try {
+      const phaseMatch =
+        killChainNames.length > 0
+          ? {
+              'stix.kill_chain_phases': {
+                $elemMatch: {
+                  phase_name: phaseName,
+                  kill_chain_name: { $in: killChainNames },
+                },
+              },
+            }
+          : { 'stix.kill_chain_phases.phase_name': phaseName };
+
       const aggregation = [
         { $sort: { 'stix.id': 1, 'stix.modified': -1 } },
         { $group: { _id: '$stix.id', document: { $first: '$$ROOT' } } },
         { $replaceRoot: { newRoot: '$document' } },
-        { $match: { 'stix.kill_chain_phases.phase_name': phaseName } },
+        { $match: phaseMatch },
         { $project: { _id: 0, __v: 0, __t: 0 } },
       ];
       return await this.model.aggregate(aggregation).exec();
@@ -33,16 +48,27 @@ class TechniqueRepository extends BaseRepository {
    * Called when a tactic's x_mitre_shortname changes so that connected techniques
    * remain consistent.
    *
+   * When killChainNames is provided, only phases whose kill_chain_name is in the
+   * list are updated — this prevents cross-domain propagation (e.g. an enterprise
+   * tactic rename should not affect mobile techniques).
+   *
    * @param {string} oldPhaseName - The previous x_mitre_shortname value
    * @param {string} newPhaseName - The new x_mitre_shortname value
+   * @param {string[]} [killChainNames] - If non-empty, restrict updates to phases
+   *   whose kill_chain_name is in this list
    * @returns {Promise<import('mongoose').UpdateWriteOpResult>}
    */
-  async updatePhaseName(oldPhaseName, newPhaseName) {
+  async updatePhaseName(oldPhaseName, newPhaseName, killChainNames = []) {
     try {
+      const arrayFilter =
+        killChainNames.length > 0
+          ? { 'elem.phase_name': oldPhaseName, 'elem.kill_chain_name': { $in: killChainNames } }
+          : { 'elem.phase_name': oldPhaseName };
+
       return await this.model.updateMany(
         { 'stix.kill_chain_phases.phase_name': oldPhaseName },
         { $set: { 'stix.kill_chain_phases.$[elem].phase_name': newPhaseName } },
-        { arrayFilters: [{ 'elem.phase_name': oldPhaseName }] },
+        { arrayFilters: [arrayFilter] },
       );
     } catch (err) {
       throw new DatabaseError(err);

--- a/app/services/meta-classes/base.service.js
+++ b/app/services/meta-classes/base.service.js
@@ -5,6 +5,7 @@ const logger = require('../../lib/logger');
 const config = require('../../config/config');
 const attackIdGenerator = require('../../lib/attack-id-generator');
 const {
+  buildAttackExternalReference,
   createAttackExternalReference,
   findAttackExternalReference,
 } = require('../../lib/external-reference-builder');
@@ -507,6 +508,17 @@ class BaseService extends ServiceWithHooks {
     // ──────────────────────────────────────────────
     // 2. COMPOSE OBJECT
     // ──────────────────────────────────────────────
+
+    // For matrices, capture the external_id from the client-provided ATT&CK reference
+    // before stripping removes it. Matrices don't have auto-generated ATT&CK IDs;
+    // their external_id is the domain name (e.g., "enterprise-attack").
+    let matrixExternalId;
+    if (data.stix?.type === 'x-mitre-matrix') {
+      matrixExternalId =
+        findAttackExternalReference(existingVersion?.stix?.external_references)?.external_id ||
+        findAttackExternalReference(data.stix?.external_references)?.external_id;
+    }
+
     BaseService.stripServerControlledFields(data, options);
     BaseService.stripEmptyStrings(data.stix);
     BaseService.stripEmptyStrings(data.workspace);
@@ -552,7 +564,13 @@ class BaseService extends ServiceWithHooks {
     }
 
     // Generate and prepend the ATT&CK external reference
-    const attackRef = createAttackExternalReference(data);
+    let attackRef;
+    if (matrixExternalId) {
+      // Matrices derive their external reference from the domain name, not workspace.attack_id
+      attackRef = buildAttackExternalReference(matrixExternalId, data.stix.type);
+    } else {
+      attackRef = createAttackExternalReference(data);
+    }
     if (attackRef) {
       data.stix.external_references.unshift(attackRef);
     }
@@ -766,6 +784,17 @@ class BaseService extends ServiceWithHooks {
     // ──────────────────────────────────────────────
     // 2. COMPOSE OBJECT
     // ──────────────────────────────────────────────
+
+    // For matrices, capture the external_id before stripping removes the client-provided
+    // ATT&CK reference. Used as a fallback when the stored document lacks one
+    // (e.g., matrices created before ATT&CK ref generation was added).
+    let matrixExternalId;
+    if (data.stix?.type === 'x-mitre-matrix') {
+      matrixExternalId =
+        findAttackExternalReference(document.stix?.external_references)?.external_id ||
+        findAttackExternalReference(data.stix?.external_references)?.external_id;
+    }
+
     BaseService.stripServerControlledFields(data, options);
     BaseService.stripEmptyStrings(data.stix);
     BaseService.stripEmptyStrings(data.workspace);
@@ -791,6 +820,12 @@ class BaseService extends ServiceWithHooks {
     const existingAttackRef = findAttackExternalReference(document.stix.external_references);
     if (existingAttackRef) {
       data.stix.external_references.unshift(existingAttackRef);
+    } else if (matrixExternalId) {
+      // Fallback for matrices created before ATT&CK ref generation was added
+      const matrixRef = buildAttackExternalReference(matrixExternalId, data.stix.type);
+      if (matrixRef) {
+        data.stix.external_references.unshift(matrixRef);
+      }
     }
 
     // ──────────────────────────────────────────────

--- a/app/services/stix/tactics-service.js
+++ b/app/services/stix/tactics-service.js
@@ -88,6 +88,7 @@ class TacticsService extends BaseService {
         tacticId: document.stix.id,
         oldShortname,
         newShortname,
+        domains: document.stix.x_mitre_domains || [],
         createNewVersion: true,
       });
 
@@ -126,6 +127,7 @@ class TacticsService extends BaseService {
         tacticId: updatedDocument.stix.id,
         oldShortname,
         newShortname,
+        domains: updatedDocument.stix.x_mitre_domains || [],
       });
 
       delete this._shortnameChange;

--- a/app/services/stix/techniques-service.js
+++ b/app/services/stix/techniques-service.js
@@ -50,13 +50,22 @@ class TechniquesService extends BaseService {
    * @param {string} payload.tacticId - STIX ID of the updated tactic
    * @param {string} payload.oldShortname - Previous x_mitre_shortname value
    * @param {string} payload.newShortname - New x_mitre_shortname value
+   * @param {string[]} payload.domains - The tactic's x_mitre_domains (e.g. ['enterprise-attack'])
    */
   static async handleTacticShortnameChanged(payload) {
-    const { tacticId, oldShortname, newShortname, createNewVersion } = payload;
+    const { tacticId, oldShortname, newShortname, domains = [], createNewVersion } = payload;
+
+    // Convert the tactic's domains to kill chain names so we only update
+    // techniques whose kill_chain_phases match both the phase_name AND the
+    // kill_chain_name.  This prevents cross-domain propagation (e.g. an
+    // enterprise tactic rename bleeding into mobile techniques).
+    const killChainNames = domains
+      .map((domain) => config.domainToKillChainMap[domain])
+      .filter(Boolean);
 
     logger.info(
       `TechniquesService: Propagating tactic shortname change '${oldShortname}' -> '${newShortname}' via ${createNewVersion ? 'new technique versions' : 'in-place update'}`,
-      { tacticId },
+      { tacticId, killChainNames },
     );
 
     if (createNewVersion) {
@@ -64,9 +73,15 @@ class TechniquesService extends BaseService {
         tacticId,
         oldShortname,
         newShortname,
+        killChainNames,
       );
     } else {
-      await TechniquesService._propagateShortnameInPlace(tacticId, oldShortname, newShortname);
+      await TechniquesService._propagateShortnameInPlace(
+        tacticId,
+        oldShortname,
+        newShortname,
+        killChainNames,
+      );
     }
   }
 
@@ -78,25 +93,37 @@ class TechniquesService extends BaseService {
    * @param {string} tacticId - STIX ID of the updated tactic (for logging)
    * @param {string} oldShortname - Previous x_mitre_shortname value
    * @param {string} newShortname - New x_mitre_shortname value
+   * @param {string[]} killChainNames - Kill chain names derived from the tactic's domains
    */
-  static async _propagateShortnameViaNewVersions(tacticId, oldShortname, newShortname) {
-    const techniques = await techniquesRepository.retrieveAllLatestByPhaseName(oldShortname);
+  static async _propagateShortnameViaNewVersions(
+    tacticId,
+    oldShortname,
+    newShortname,
+    killChainNames,
+  ) {
+    const techniques = await techniquesRepository.retrieveAllLatestByPhaseName(
+      oldShortname,
+      killChainNames,
+    );
 
     logger.info(
       `TechniquesService: Creating new versions for ${techniques.length} technique(s) due to tactic shortname change`,
-      { tacticId, oldShortname, newShortname },
+      { tacticId, oldShortname, newShortname, killChainNames },
     );
 
     for (const technique of techniques) {
       try {
-        // Clone stix shallowly — only kill_chain_phases needs to change
+        // Clone stix shallowly — only kill_chain_phases needs to change.
+        // Only rename phases that match BOTH the old phase_name AND one of the
+        // tactic's kill chain names, so cross-domain phases are left untouched.
         const newVersion = {
           ...technique,
           stix: {
             ...technique.stix,
             modified: new Date().toISOString(),
             kill_chain_phases: (technique.stix.kill_chain_phases || []).map((phase) =>
-              phase.phase_name === oldShortname
+              phase.phase_name === oldShortname &&
+              (killChainNames.length === 0 || killChainNames.includes(phase.kill_chain_name))
                 ? { ...phase, phase_name: newShortname }
                 : { ...phase },
             ),
@@ -125,13 +152,18 @@ class TechniquesService extends BaseService {
    * @param {string} tacticId - STIX ID of the updated tactic (for logging)
    * @param {string} oldShortname - Previous x_mitre_shortname value
    * @param {string} newShortname - New x_mitre_shortname value
+   * @param {string[]} killChainNames - Kill chain names derived from the tactic's domains
    */
-  static async _propagateShortnameInPlace(tacticId, oldShortname, newShortname) {
+  static async _propagateShortnameInPlace(tacticId, oldShortname, newShortname, killChainNames) {
     try {
-      const result = await techniquesRepository.updatePhaseName(oldShortname, newShortname);
+      const result = await techniquesRepository.updatePhaseName(
+        oldShortname,
+        newShortname,
+        killChainNames,
+      );
       logger.info(
         `TechniquesService: Updated ${result.modifiedCount} technique document(s) in-place for tactic shortname change`,
-        { tacticId, oldShortname, newShortname },
+        { tacticId, oldShortname, newShortname, killChainNames },
       );
     } catch (error) {
       logger.error(


### PR DESCRIPTION
Matrices don't have auto-generated ATT&CK IDs, so the existing external reference pipeline silently dropped their mitre-attack ref after stripping. Capture the domain-based external_id (e.g.,'enterprise-attack') from the client-provided ref before stripping, then build the correct reference with the proper URL (e.g., /matrices/enterprise instead of /matrices/enterprise-attack).