### PR TITLE
Update software service type for revoke functionality

### DIFF
--- a/app/services/meta-classes/base.service.js
+++ b/app/services/meta-classes/base.service.js
@@ -969,9 +969,10 @@ class BaseService extends ServiceWithHooks {
         details: `Object B with stixId ${data.revoking.stixId} and modified ${data.revoking.modified} not found`,
       });
     }
-    if (objectB.stix.type !== this.type) {
+    const expectedRevokingType = this.type === 'software' ? objectA.stix.type : this.type;
+    if (objectB.stix.type !== expectedRevokingType) {
       throw new BadRequestError({
-        details: `Revoking object must be of the same type (${this.type}), got ${objectB.stix.type}`,
+        details: `Revoking object must be of the same type (${expectedRevokingType}), got ${objectB.stix.type}`,
       });
     }
 

--- a/app/services/stix/software-service.js
+++ b/app/services/stix/software-service.js
@@ -92,4 +92,4 @@ class SoftwareService extends BaseService {
   }
 }
 
-module.exports = new SoftwareService(null, softwareRepository);
+module.exports = new SoftwareService('software', softwareRepository);


### PR DESCRIPTION
Update software service type so revoke works as expected for malware and tool. Related to [PR](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/pull/820) on the front end.