### PR TITLE
feat(data-components): support domain filtering

### DIFF
--- a/app/api/definitions/paths/data-components-paths.yml
+++ b/app/api/definitions/paths/data-components-paths.yml
@@ -61,6 +61,18 @@ paths:
             type: string
           allowReserved: true
           example: 'windows'
+        - name: domain
+          in: query
+          description: |
+            Only return data components in the given domain.
+            This parameter may be set multiple times to retrieve data components in any of the provided domains.
+          schema:
+            oneOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
+          example: 'enterprise-attack'
         - name: lastUpdatedBy
           in: query
           description: |

--- a/app/controllers/data-components-controller.js
+++ b/app/controllers/data-components-controller.js
@@ -11,6 +11,7 @@ exports.retrieveAll = async function (req, res, next) {
     includeRevoked: req.query.includeRevoked,
     includeDeprecated: req.query.includeDeprecated,
     search: req.query.search,
+    domain: req.query.domain,
     lastUpdatedBy: req.query.lastUpdatedBy,
     includePagination: req.query.includePagination,
   };

--- a/app/tests/api/data-components/data-components.spec.js
+++ b/app/tests/api/data-components/data-components.spec.js
@@ -138,7 +138,7 @@ describe('Data Components API', function () {
     const res = await request(app)
       .get('/api/data-components?domain=enterprise-attack')
       .set('Accept', 'application/json')
-      .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+      .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
       .expect(200)
       .expect('Content-Type', /json/);
 
@@ -153,7 +153,7 @@ describe('Data Components API', function () {
     const res = await request(app)
       .get('/api/data-components?domain=enterprise-attack&domain=mobile-attack')
       .set('Accept', 'application/json')
-      .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+      .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
       .expect(200)
       .expect('Content-Type', /json/);
 
@@ -168,7 +168,7 @@ describe('Data Components API', function () {
     const res = await request(app)
       .get('/api/data-components?domain=not-a-domain')
       .set('Accept', 'application/json')
-      .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+      .set('Cookie', `${passportCookie.name}=${passportCookie.value}`)
       .expect(200)
       .expect('Content-Type', /json/);
 

--- a/app/tests/api/data-components/data-components.spec.js
+++ b/app/tests/api/data-components/data-components.spec.js
@@ -134,6 +134,50 @@ describe('Data Components API', function () {
     expect(dataComponent.length).toBe(1);
   });
 
+  it('GET /api/data-components should return data components containing the domain', async function () {
+    const res = await request(app)
+      .get('/api/data-components?domain=enterprise-attack')
+      .set('Accept', 'application/json')
+      .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+      .expect(200)
+      .expect('Content-Type', /json/);
+
+    const dataComponents = res.body;
+    expect(dataComponents).toBeDefined();
+    expect(Array.isArray(dataComponents)).toBe(true);
+    expect(dataComponents.length).toBe(1);
+    expect(dataComponents[0].stix.x_mitre_domains).toContain('enterprise-attack');
+  });
+
+  it('GET /api/data-components should return data components containing any provided domain', async function () {
+    const res = await request(app)
+      .get('/api/data-components?domain=enterprise-attack&domain=mobile-attack')
+      .set('Accept', 'application/json')
+      .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+      .expect(200)
+      .expect('Content-Type', /json/);
+
+    const dataComponents = res.body;
+    expect(dataComponents).toBeDefined();
+    expect(Array.isArray(dataComponents)).toBe(true);
+    expect(dataComponents.length).toBe(1);
+    expect(dataComponents[0].stix.x_mitre_domains).toContain('enterprise-attack');
+  });
+
+  it('GET /api/data-components should not return any data components when searching for a non-existent domain', async function () {
+    const res = await request(app)
+      .get('/api/data-components?domain=not-a-domain')
+      .set('Accept', 'application/json')
+      .set('Cookie', `${login.passportCookieName}=${passportCookie.value}`)
+      .expect(200)
+      .expect('Content-Type', /json/);
+
+    const dataComponents = res.body;
+    expect(dataComponents).toBeDefined();
+    expect(Array.isArray(dataComponents)).toBe(true);
+    expect(dataComponents.length).toBe(0);
+  });
+
   it('GET /api/data-components/:id/channels returns the log source channels of the added data component', async function () {
     const res = await request(app)
       .get('/api/data-components/' + dataComponent1.stix.id + '/channels')


### PR DESCRIPTION
## Why

Data Component list views need domain filtering support so users can narrow the list by ATT&CK domain.

- Closes #471.
- Closes #453 as the related REST API companion/duplicate issue for the same Data Components domain filtering need.
- Related frontend issue: [frontend#767](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/issues/767).

## What Changed
- Pass the `domain` query parameter through `GET /api/data-components`.
- Document the `domain` parameter for Data Components in the OpenAPI path definition.
- Add endpoint coverage for matching, repeated, and non-matching domain filters.

## Test Strategy
The shared repository tests already cover the core single-domain and multi-domain query behavior. This PR adds focused API coverage for the issue-closing endpoint so `GET /api/data-components?domain=...` accepts the filter, passes it into the retrieval path, and returns persisted objects with matching `stix.x_mitre_domains` values.

## How To Verify
- `npm test`
- On a running instance with matching test data, call `GET /api/data-components?domain=enterprise-attack` or `GET /api/data-components?domain=ics-attack` and confirm returned objects contain that value in `stix.x_mitre_domains`.
- Call `GET /api/data-components?domain=not-a-domain` and confirm it returns an empty array.
- Confirm the OpenAPI docs show the `domain` query parameter for Data Components.