### PR TITLE
Grab-bag of validation improvements

### DIFF
--- a/app/services/meta-classes/base.service.js
+++ b/app/services/meta-classes/base.service.js
@@ -355,6 +355,12 @@ class BaseService extends ServiceWithHooks {
       delete stix[field];
     }
 
+    // Strip workspace.validation — server-controlled; recomputed on every
+    // create/update so a stale entry from a prior GET cannot ride along.
+    if (data.workspace) {
+      delete data.workspace.validation;
+    }
+
     if (!options.preserveAttackId) {
       // Strip workspace.attack_id — server generates/carries forward
       if (data.workspace) {
@@ -695,6 +701,12 @@ class BaseService extends ServiceWithHooks {
    * @private
    */
   async _createFromImport(data, options) {
+    // Strip workspace.validation — server-controlled; the fail-open block
+    // below is the only legitimate writer of this field on the import path.
+    if (data.workspace) {
+      delete data.workspace.validation;
+    }
+
     // Extract ATT&CK ID from external_references and propagate to workspace.attack_id
     const attackIdInExternalReferences = attackIdGenerator.extractAttackIdFromExternalReferences(
       data.stix,

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -26,6 +26,7 @@ JSON configuration files, or a combination of both.
       - [Basic API Key](#basic-api-key)
       - [Multiple Service Authentication Methods](#multiple-service-authentication-methods)
     - [Scheduler](#scheduler)
+    - [Validation](#validation)
     - [Collection Indexes](#collection-indexes)
     - [Configuration Files](#configuration-files)
     - [ATT\&CK Specific](#attck-specific)
@@ -530,6 +531,59 @@ Background job scheduler configuration.
 ```bash
 ENABLE_SCHEDULER=true
 CHECK_WORKBENCH_INTERVAL=30
+```
+
+### Validation
+
+Configuration for ATT&CK Data Model (ADM) request validation and the scheduled re-validation task.
+
+| Option            | Environment Variable        | JSON Path                              | Type    | Default     | Description                                                                                  |
+|-------------------|-----------------------------|----------------------------------------|---------|-------------|----------------------------------------------------------------------------------------------|
+| Validate Requests | `VALIDATE_WITH_ADM_SCHEMAS` | `validateRequests.withAttackDataModel` | boolean | `false`     | Run incoming POST/PUT bodies through the ADM schemas before persisting                       |
+| Re-validate Cron  | `VALIDATE_OBJECTS_CRON`     | `scheduler.validateObjectsCron`        | string  | `0 3 * * *` | Cron pattern for the background task that refreshes `workspace.validation` on every document |
+| ADM Log Level     | `ADM_LOG_LEVEL`             | *(env only)*                           | enum    | `warn`      | Verbosity of the ADM library's internal logger                                               |
+
+**`VALIDATE_WITH_ADM_SCHEMAS`**
+
+When enabled, every POST and PUT validates the composed STIX payload against the ADM schemas before saving. Failed validations cause the request to throw with an HTTP error and the document is not persisted. When disabled, the write pipeline does not gate on ADM compliance and downstream tools are responsible for detecting non-compliant content.
+
+This setting does not affect the legacy OpenAPI request validation (`VALIDATE_WITH_LEGACY_SCHEMAS`), which can be enabled or disabled independently.
+
+**`VALIDATE_OBJECTS_CRON`**
+
+The Workbench scheduler periodically re-validates every SDO and SRO in the database against the current ADM and refreshes each document's `workspace.validation` field. This combats *concept drift*: documents that passed validation under an older ADM version may become non-compliant after a Workbench upgrade.
+
+The cron pattern follows standard 5-field syntax (`minute hour day-of-month month day-of-week`). The default `0 3 * * *` runs the task daily at 3:00 AM. The task is skipped entirely if the global scheduler is disabled (`ENABLE_SCHEDULER=false`).
+
+For the lifecycle of `workspace.validation` itself, see [Stateful Validation Tracking](../developer/workspace-validation.md).
+
+**`ADM_LOG_LEVEL`**
+
+Read by the `@mitre-attack/attack-data-model` library directly — *not* a Convict-managed setting and not configurable via `JSON_CONFIG_PATH`. It controls the verbosity of the ADM library's own logger, which is independent of the Workbench `LOG_LEVEL`.
+
+This was introduced primarily to suppress the deprecation warning that the ADM emits for every relationship in the database during a re-validation run. Setting `ADM_LOG_LEVEL=error` (or `silent`) keeps the scheduled task quiet without affecting Workbench's own logs.
+
+| Level    | Description                                                        |
+|----------|--------------------------------------------------------------------|
+| `debug`  | Verbose diagnostic output                                          |
+| `info`   | Informational status messages (data retrieval, parse counts, etc.) |
+| `warn`   | Validation issues in `relaxed` mode and deprecation warnings       |
+| `error`  | Errors only                                                        |
+| `silent` | Disables all output                                                |
+
+Levels are inclusive: setting `info` enables `info`, `warn`, and `error`. The default is `warn`.
+
+**Examples:**
+
+```bash
+# Enable ADM-based request validation
+VALIDATE_WITH_ADM_SCHEMAS=true
+
+# Run re-validation hourly instead of daily at 3 AM
+VALIDATE_OBJECTS_CRON=0 * * * *
+
+# Suppress noisy ADM deprecation warnings during scheduler runs
+ADM_LOG_LEVEL=error
 ```
 
 ### Collection Indexes

--- a/docs/developer/workspace-validation.md
+++ b/docs/developer/workspace-validation.md
@@ -1,0 +1,202 @@
+# Stateful Validation Tracking (`workspace.validation`)
+
+## Overview
+
+Every Mongoose document in the Workbench REST API has an optional
+`workspace.validation` subdocument that records the result of validating
+the document's `stix` payload against the [ATT&CK Data Model
+(ADM)](https://github.com/mitre-attack/attack-data-model) schemas.
+
+The field is **server-controlled** and **diagnostic**: it does not
+gate reads, but it tells operators and client UIs which documents are
+known to fail current ADM validation and why. It exists so that a long-
+lived database can carry forward documents that were valid under an
+older ADM version (or that pre-date validation entirely) without losing
+visibility into their non-compliance.
+
+This document defines the field, its invariants, and the pipelines that
+write or clear it.
+
+## Why state-track validation at all?
+
+ADM validation is the gate at the write boundary: every POST and PUT
+runs the composed STIX object through the ADM schemas before
+persistence (see [`base.service.js`](../../app/services/meta-classes/base.service.js)
+pipeline stage 5, "VALIDATE WITH ADM"). If validation fails on a write,
+the request throws and nothing is persisted.
+
+Given that gate, **a freshly-seeded database should never contain
+validation errors.** State-tracking is only meaningful for documents
+that bypassed the gate or were validated under different rules:
+
+1. **Legacy content** — documents that existed before ADM-based
+   validation was introduced into the request pipeline. These
+   documents may have shapes that current schemas reject and were
+   never gated on entry.
+
+2. **Version-skewed content** — documents written under one ADM
+   version that subsequently became non-compliant when Workbench
+   upgraded to a later ADM version. For example, content authored
+   under ADM v1.0 may fail ADM v2.0 validation if v2.0 tightened a
+   constraint or renamed a required field.
+
+   Schema-changing Workbench upgrades are expected to ship database
+   migration scripts that bring existing content into compliance, so
+   this case should be rare in practice. It remains technically
+   possible whenever an upgrade lands without a corresponding migration,
+   or when a migration cannot fully repair a document.
+
+3. **Imported content** — STIX bundle imports use a fail-open path
+   (see below). When an imported object fails validation but the
+   import is allowed to proceed, the errors are recorded on the
+   document so they are visible after the import completes.
+
+## Field shape
+
+```jsonc
+{
+  "workspace": {
+    "validation": {
+      "errors": [
+        { "message": "stix.x_mitre_domains is Required",
+          "path": ["x_mitre_domains"],
+          "code": "invalid_type" }
+      ],
+      "attack_spec_version": "3.3.0",
+      "adm_version": "1.4.2",
+      "validated_at": "2026-05-06T12:00:00.000Z"
+    }
+  }
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `errors` | Array of `{ message, path, code }` derived from Zod issues, after bypass rules are applied. |
+| `attack_spec_version` | ATT&CK spec version under which validation was performed. |
+| `adm_version` | NPM version of `@mitre-attack/attack-data-model` at validation time. |
+| `validated_at` | UTC timestamp of the validation run. |
+
+The presence of the `validation` subdocument means "this document had
+unresolved errors as of `validated_at`." Its **absence** means "this
+document was either never validated or last passed validation."
+
+## Invariants
+
+1. `workspace.validation` is **server-controlled.** Clients cannot
+   set, modify, or carry forward this field through any write path.
+2. The field is **recomputed (or omitted) on every successful write.**
+   A POST or PUT that passes ADM validation produces a document with
+   no `workspace.validation`. A POST or PUT that fails ADM validation
+   throws — nothing is persisted, and the prior document (if any) is
+   untouched until a future write or scheduler tick revisits it.
+3. The only paths that may legitimately *set* `workspace.validation`
+   are the scheduler and the import fail-open path. All other paths
+   either clear it or leave it absent.
+
+## Writers and behavior
+
+### 1. `BaseService.create()` — POST a new (version of an) object
+
+[`base.service.js`](../../app/services/meta-classes/base.service.js)
+
+- `stripServerControlledFields()` removes any client-supplied
+  `workspace.validation` at the top of the pipeline.
+- ADM validation runs.
+- If validation fails, the request throws — nothing persists.
+- If validation passes, the new document is saved with no
+  `workspace.validation`.
+
+### 2. `BaseService.updateFull()` — PUT an existing version
+
+- `stripServerControlledFields()` removes any client-supplied
+  `workspace.validation`.
+- ADM validation runs against the composed object.
+- If validation fails, the request throws — the existing document is
+  untouched.
+- If validation passes:
+  - The composed document is merged onto the existing one.
+  - If the existing document had `workspace.validation`, the merge
+    sets it to `undefined` and a follow-up `repository.unsetField`
+    call removes the field from the persisted document.
+
+### 3. `BaseService._createFromImport()` — STIX bundle import
+
+This path is intentionally **fail-open**: import is the primary way
+that legacy and version-skewed content enters the system, so blocking
+on every validation error would make migrations impossible.
+
+- Any client-supplied `workspace.validation` is stripped at entry.
+- Revoked or deprecated objects skip validation entirely and are
+  persisted with no `workspace.validation`.
+- Otherwise, ADM validation runs.
+- If validation fails and `options.validateContents` is set, the
+  import throws.
+- If validation fails and `validateContents` is not set, the errors
+  are recorded on `workspace.validation` (with current ADM and spec
+  versions) and the document persists. **This is the only legitimate
+  client-facing setter.**
+- If validation passes, the document persists with no
+  `workspace.validation`.
+
+### 4. The `validate-objects` scheduler task
+
+[`app/scheduler/validate-objects-task.js`](../../app/scheduler/validate-objects-task.js)
+
+The scheduler exists to combat **concept drift**: a document that
+passed validation last week may fail today if Workbench has since
+upgraded ADM. On its configured cron schedule, the task iterates every
+SDO and SRO in the database, re-runs validation, and brings each
+document's `workspace.validation` field back in sync with the current
+ADM rules.
+
+For each document:
+
+- Revoked/deprecated objects are skipped (validation is not
+  meaningful for retired content).
+- Validation runs and bypass rules are applied.
+- If the document passes, any existing `workspace.validation` is
+  unset (`totalCleared`).
+- If the document fails, `workspace.validation` is set to the current
+  errors with current ADM/spec versions (`totalErrored`).
+
+Because the scheduler is the only writer that can transition a
+document from "valid" to "has-validation-errors" without a user
+write, it is also the only mechanism that surfaces version-skewed
+documents after a Workbench upgrade.
+
+## Lifecycle summary
+
+| Path | Validation outcome | `workspace.validation` after the write |
+|---|---|---|
+| `create()` | passes | absent |
+| `create()` | fails | request throws; nothing persisted |
+| `updateFull()` | passes | absent (cleared if previously present) |
+| `updateFull()` | fails | request throws; existing doc untouched |
+| `_createFromImport()` | passes | absent |
+| `_createFromImport()` | fails + `validateContents` | request throws |
+| `_createFromImport()` | fails + fail-open | server-set with current ADM/spec |
+| `_createFromImport()` | revoked/deprecated | absent |
+| Scheduler | passes | absent (cleared if previously present) |
+| Scheduler | fails | server-set with current ADM/spec |
+
+## Bypass rules
+
+Both the request pipeline and the scheduler consult
+`validation-bypasses-repository` to filter Zod issues that match a
+stored bypass rule (matching on `stixType`, `errorCode`, and
+`fieldPath`). A bypassed error is removed from the `errors` array
+before the field is written. This allows operators to suppress known-
+benign validation noise without modifying ADM itself.
+
+The set of bypass rules is shared between the synchronous write path
+and the scheduler so that a document's validation status is consistent
+regardless of which writer last touched it.
+
+## Reading `workspace.validation`
+
+There is no public endpoint that filters on this field today. Clients
+that need to surface "documents needing attention" should retrieve
+the relevant collection and check for the presence of
+`workspace.validation` on each document. The field is a diagnostic
+hint, not a workflow gate — read paths do not consult it.

--- a/migrations/20260429172049-remove-empty-array-fields.js
+++ b/migrations/20260429172049-remove-empty-array-fields.js
@@ -1,0 +1,81 @@
+'use strict';
+
+/**
+ * Remove empty array values from STIX fields that previously defaulted to [].
+ *
+ * Mongoose's default behavior for `[String]` schema fields is to initialize
+ * them as empty arrays. The STIX 2.1 specification states that list properties
+ * MUST NOT be empty — they should be absent rather than present as `[]`.
+ *
+ * The corresponding model schemas have been updated to `{ type: [String], default: undefined }`
+ * so new documents will omit these fields when not populated. This migration
+ * cleans up existing documents that already have empty arrays stored.
+ */
+
+// Every array field that should be omitted rather than stored as [].
+const fields = [
+  'stix.external_references',
+  'stix.object_marking_refs',
+  'stix.aliases',
+  'stix.roles',
+  'stix.sectors',
+  'stix.tactic_refs',
+  'stix.x_mitre_aliases',
+  'stix.x_mitre_analytic_refs',
+  'stix.x_mitre_collection_layers',
+  'stix.x_mitre_log_source_references',
+  'stix.x_mitre_mutable_elements',
+  'stix.x_mitre_contributors',
+  'stix.x_mitre_domains',
+  'stix.x_mitre_platforms',
+  'stix.x_mitre_data_sources',
+  'stix.x_mitre_effective_permissions',
+  'stix.x_mitre_permissions_required',
+  'stix.x_mitre_system_requirements',
+  'stix.kill_chain_phases',
+  'stix.x_mitre_defense_bypassed',
+  'stix.x_mitre_tactic_type',
+  'stix.x_mitre_contents',
+  'workspace.embedded_relationships',
+  'workspace.collections',
+];
+
+const collectionNames = ['attackObjects', 'relationships'];
+
+module.exports = {
+  async up(db) {
+    let totalModified = 0;
+
+    // Unset each field individually so we only remove fields that are actually
+    // empty arrays — not populated fields on the same document.
+    for (const collectionName of collectionNames) {
+      const collection = db.collection(collectionName);
+      for (const field of fields) {
+        const result = await collection.updateMany(
+          { [field]: { $eq: [] } },
+          { $unset: { [field]: '' } },
+        );
+        if (result.modifiedCount > 0) {
+          console.log(
+            `Removed empty ${field} from ${result.modifiedCount} ${collectionName} document(s)`,
+          );
+          totalModified += result.modifiedCount;
+        }
+      }
+    }
+
+    console.log(`Total documents updated: ${totalModified}`);
+  },
+
+  async down(db) {
+    // Restore empty arrays on documents that are missing these fields.
+    // This is a best-effort reverse — it cannot distinguish between fields that
+    // were never set vs fields that were unset by the up() migration.
+    for (const collectionName of collectionNames) {
+      const collection = db.collection(collectionName);
+      for (const field of fields) {
+        await collection.updateMany({ [field]: { $exists: false } }, { $set: { [field]: [] } });
+      }
+    }
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^13.0.1",
-        "@mitre-attack/attack-data-model": "^4.10.1",
+        "@mitre-attack/attack-data-model": "^4.11.0",
         "async": "^3.2.6",
         "async-await-retry": "^2.1.0",
         "body-parser": "^2.2.1",
@@ -878,9 +878,9 @@
       "license": "MIT"
     },
     "node_modules/@mitre-attack/attack-data-model": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/@mitre-attack/attack-data-model/-/attack-data-model-4.10.1.tgz",
-      "integrity": "sha512-6LqYuG44HFLEX0JT1+KJLImHNERwM+lndgBKOTi35gD5+8ZNH0dWJqN3YAYMYvcbJ3QFCMyTcWupSE8z34lH7A==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@mitre-attack/attack-data-model/-/attack-data-model-4.11.0.tgz",
+      "integrity": "sha512-U9CsivFwg6EVeM4edjNQYm6LJXbQbNzIcvixjRSdp5qOCFRi2UwL1CVa2QwE9ZXuNN19ZOH9eEdQcmmL+uowOA==",
       "license": "APACHE-2.0",
       "dependencies": {
         "axios": "^1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^13.0.1",
-        "@mitre-attack/attack-data-model": "^4.10.0",
+        "@mitre-attack/attack-data-model": "^4.10.1",
         "async": "^3.2.6",
         "async-await-retry": "^2.1.0",
         "body-parser": "^2.2.1",
@@ -878,9 +878,9 @@
       "license": "MIT"
     },
     "node_modules/@mitre-attack/attack-data-model": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@mitre-attack/attack-data-model/-/attack-data-model-4.10.0.tgz",
-      "integrity": "sha512-whLa1X8GURoNvKgpbAqZe2EymL9I5/ncbdRSDKgfYeYkt0iu3FwfzKVIlcq2sn5gKZ68o94kxSM5TDsi+2r6PA==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@mitre-attack/attack-data-model/-/attack-data-model-4.10.1.tgz",
+      "integrity": "sha512-6LqYuG44HFLEX0JT1+KJLImHNERwM+lndgBKOTi35gD5+8ZNH0dWJqN3YAYMYvcbJ3QFCMyTcWupSE8z34lH7A==",
       "license": "APACHE-2.0",
       "dependencies": {
         "axios": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^13.0.1",
-    "@mitre-attack/attack-data-model": "^4.10.1",
+    "@mitre-attack/attack-data-model": "^4.11.0",
     "async": "^3.2.6",
     "async-await-retry": "^2.1.0",
     "body-parser": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^13.0.1",
-    "@mitre-attack/attack-data-model": "^4.10.0",
+    "@mitre-attack/attack-data-model": "^4.10.1",
     "async": "^3.2.6",
     "async-await-retry": "^2.1.0",
     "body-parser": "^2.2.1",

--- a/template.env
+++ b/template.env
@@ -71,6 +71,26 @@ DATABASE_URL=
 # Default: 10
 #CHECK_WORKBENCH_INTERVAL=10
 
+# Validation
+# VALIDATE_WITH_ADM_SCHEMAS (bool) - Validate POST/PUT bodies against the ATT&CK Data Model
+# When true, requests that fail ADM validation are rejected before persistence.
+# Default: false
+#VALIDATE_WITH_ADM_SCHEMAS=false
+
+# VALIDATE_OBJECTS_CRON (string) - Cron pattern for the scheduled re-validation task
+# Re-validates every SDO/SRO against the current ADM and refreshes workspace.validation.
+# Standard 5-field cron syntax (minute hour day-of-month month day-of-week).
+# Skipped entirely when ENABLE_SCHEDULER=false.
+# Default: 0 3 * * *  (daily at 3:00 AM)
+#VALIDATE_OBJECTS_CRON=0 3 * * *
+
+# ADM_LOG_LEVEL (enum) - Verbosity of the @mitre-attack/attack-data-model library's logger
+# Read by the ADM library directly; independent of LOG_LEVEL and not configurable via JSON.
+# Options: debug, info, warn, error, silent  (inclusive — info enables info+warn+error)
+# Set to error or silent to suppress per-relationship deprecation warnings during scheduler runs.
+# Default: warn
+#ADM_LOG_LEVEL=warn
+
 # Session
 # SESSION_SECRET (string) - Secret to sign session cookies.
 # Default: securely generated at startup (changes on restart; not recommended for production).


### PR DESCRIPTION
## Fix 1 - expand scope of the migration script that removes empty arrays

Found historical evidence of the following keys being empty arrays: 

- `x_mitre_data_sources`
- `x_mitre_effective_permissions`
- `x_mitre_permissions_required`
- `x_mitre_system_requirements`
- `kill_chain_phases`
- `x_mitre_defense_bypassed`
- `x_mitre_tactic_type`

These fields will be popped/stripped from Mongo documents if they exist and are empty arrays.

## Fix 2 - treat `workspace.validation` as server-controlled

Strip `workspace.validation` from incoming data in standard POST requests and during STIX Bundle import operations, so a stale entry from a prior GET cannot ride along into the saved document, and so users cannot forge custom `workspace.validation` payloads. The field is now exclusively written by the scheduler and the STIX Bundle import fail-open path.

## Fix 3 - upgrade ADM

Bumping `@mitre-attack/attack-data-model` to `v4.11.0` does two things:

1. It exposes `ADM_LOG_LEVEL` to enable control over stdout/stderr message emitting from the ADM library. This is necessary because before, every SRO validation attempt yielded a deprecation warning, which was filling the server logs with tens of thousands of logs. We can now suppress those by setting `ADM_LOG_LEVEL`.

2. It applies a hotfix to the detection strategies schema that makes `x_mitre_contributors` optional, thereby resolving ~900 false positive validation errors on DETs in the v19.0 release.

## Documentation

* Updates `template.env` and `docs/admin/configuration.md` with validation-oriented environment variables — THESE SHOULD BE COPIED TO THE attack-workbench-deployment REPO

  * `VALIDATE_WITH_ADM_SCHEMAS`: global toggle for enabling/disabling ADM validation
  * `VALIDATE_OBJECTS_CRON`: sets the periodicity for the scheduler task which maintains `workspace.validation`
  * `ADM_LOG_LEVEL`: configures the log level for the underlying ADM library, defaults to a mode which suppresses noisy SRO deprecation warnings

* Adds `docs/developer/workspace-validation.md` explaining what stateful validation tracking is, why the field exists, and how writes to this key are gated.